### PR TITLE
Use Puma in clustered mode

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -22,14 +22,14 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
This updates Puma server config to boot in clustered mode with two processes running. 

For more info, see: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server