### PR TITLE
Update active storage config

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,10 +9,7 @@ local:
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:
   service: S3
-  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
-  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-  region: eu-west-2
-  bucket: tenjin-quiz
+  bucket: <%= ENV['AWS_S3_BUCKET'] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
Removes options read from env by default. See https://edgeguides.rubyonrails.org/active_storage_overview.html#amazon-s3-service

This causes region to be read from the environment, which fixes running on OGAT infrastructure.