### PR TITLE
Remove parallelism for CI testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           RAILS_ENV: test
   test:
     <<: *default_job
-    parallelism: 2
+    parallelism: 1
     docker:
       - image: circleci/ruby:2.6.3-node-browsers
         environment:


### PR DESCRIPTION
Parallel testing appears to be breaking our test suite.  Remove for now so other changes can go through, and investigate the reasons why for future releases.