### PR TITLE
Update mail config

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+DEFAULT_MAIL_SENDER=foo@bar.com

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV['DEFAULT_EMAIL_FROM']
+  default from: ENV['DEFAULT_MAIL_SENDER']
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserMailer < ApplicationMailer
-  default from: ENV['DEFAULT_EMAIL_FROM']
+  default from: ENV['DEFAULT_MAIL_SENDER']
 
   def setup_email
     @user = params[:user]

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,5 @@ module Csquiz
     config.action_mailer.delivery_method = :ses
 
     config.action_mailer.asset_host = ENV['ASSET_HOST']
-    config.action_mailer.default_url_options = { host: ENV['DEFAULT_EMAIL_FROM'] }
-
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Provide a default URL host for mailers
+  config.action_mailer.default_url_options = { host: 'localhost', port: ENV.fetch('PORT') { 3000 } }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.default_url_options = { host: ENV['DEFAULT_HOST'], protocol: 'https' }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,6 +45,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   config.action_mailer.asset_host = "http://example.com"
+  config.action_mailer.default_url_options = { host: 'example.com' }
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV['DEFAULT_EMAIL_FROM']
+  config.mailer_sender = ENV['DEFAULT_MAIL_SENDER']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Primarily, this defines use of https in production for mail links and allows for current situation of having different mail and application hosts. Splits previous single var into:

- `DEFAULT_MAIL_SENDER`, defined as an email or email with name e.g. `OGAT Tenjin <no-reply@outwood.com>`
- `DEFAULT_HOST`, defined as the default application host, e.g. `tenjin.outwood.com`