### PR TITLE
Serve static assets with cache control headers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,10 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, s-maxage=31536000, max-age=15552000',
+    'Expires' => 1.year.from_now.to_formatted_s(:rfc822)
+  }
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
Adds `Cache-Control` and `Expires` headers to files served from public file server.