### PR TITLE
Generate CORS headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rails', '~> 6.0.0'
 
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.3'
+gem 'rack-cors'
 gem 'rack-timeout'
 gem 'sprockets', '3.7.2' # Fix at 3.7.2 as 4.0.0 as issues with sassc compilation
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '~> 6.0.0'
 
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.3'
-gem 'rack-cors'
+gem 'rack-cors', groups: [:production]
 gem 'rack-timeout'
 gem 'sprockets', '3.7.2' # Fix at 3.7.2 as 4.0.0 as issues with sassc compilation
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,6 +275,8 @@ GEM
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.8)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -493,6 +495,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.3)
   pundit
+  rack-cors
   rack-timeout
   rails (~> 6.0.0)
   rails-controller-testing

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,8 @@
 if defined? Rack::Cors
   Rails.configuration.middleware.insert_before 0, Rack::Cors do
     allow do
-      origins("https://#{ENV['DEFAULT_HOST']}")
+      origins(ENV.fetch('CORS_ORIGINS', '').split(',').map(&:strip))
+
       resource '/assets/*', headers: :any, methods: %i[get head options]
       resource '/packs/*', headers: :any, methods: %i[get head options]
     end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Configure Rack::Cors middleware
+#
+# Add CORS headers when serving assets
+# Whitelist permitted frontend origins
+if defined? Rack::Cors
+  Rails.configuration.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins("https://#{ENV['DEFAULT_HOST']}")
+      resource '/assets/*', headers: :any, methods: %i[get head options]
+      resource '/packs/*', headers: :any, methods: %i[get head options]
+    end
+  end
+end


### PR DESCRIPTION
Adds rack-cors middleware. 

This adds cross-origin resource sharing headers to matching resources, permitting assets such as fonts & scripts to be served from a different origin.

Note that _all_ permitted origins for an environment that uses a cross-origin asset host need to be specified. So , e.g. for availability at both *.outwood.com and *.herokuapp.com in prod, `CORS_ORIGINS` would need to include both urls, comma-separated. 