### PR TITLE
feat(navbar): rebuild against --tj-* tokens, drop Bootstrap component classes

### DIFF
--- a/app/javascript/packs/controllers/navbar_controller.js
+++ b/app/javascript/packs/controllers/navbar_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['menu', 'toggler']
+
+  toggle () {
+    const isOpen = this.menuTarget.classList.toggle('tj-navbar__collapse--open')
+    this.togglerTarget.setAttribute('aria-expanded', isOpen.toString())
+  }
+
+  toggleDropdown (event) {
+    const dropdown = event.currentTarget.closest('.tj-navbar__dropdown')
+    const isOpen = dropdown.classList.toggle('tj-navbar__dropdown--open')
+    // Close other open dropdowns
+    this.element.querySelectorAll('.tj-navbar__dropdown--open').forEach(d => {
+      if (d !== dropdown) d.classList.remove('tj-navbar__dropdown--open')
+    })
+    event.stopPropagation()
+  }
+
+  // Close dropdowns when clicking outside the navbar
+  closeDropdowns (event) {
+    if (!this.element.contains(event.target)) {
+      this.element.querySelectorAll('.tj-navbar__dropdown--open').forEach(d => {
+        d.classList.remove('tj-navbar__dropdown--open')
+      })
+    }
+  }
+
+  connect () {
+    this._outsideClick = this.closeDropdowns.bind(this)
+    document.addEventListener('click', this._outsideClick)
+  }
+
+  disconnect () {
+    document.removeEventListener('click', this._outsideClick)
+  }
+}

--- a/app/javascript/packs/pages.js
+++ b/app/javascript/packs/pages.js
@@ -1,11 +1,11 @@
 $(document).on('turbo:load', function () {
   if (page.controller() === 'pages' && page.action() === 'show') {
     if (location.href.indexOf('about') === -1) {
-      $('#navbar-main').addClass('fixed-top')
-      $('#navbar-main').removeClass('bg-dark')
+      $('#navbar-main').addClass('tj-navbar--fixed')
+      $('#navbar-main').removeClass('tj-navbar--dark')
     } else {
-      $('#navbar-main').removeClass('fixed-top')
-      $('#navbar-main').addClass('bg-dark')
+      $('#navbar-main').removeClass('tj-navbar--fixed')
+      $('#navbar-main').addClass('tj-navbar--dark')
     }
   }
 })

--- a/app/javascript/styles/_navbar.scss
+++ b/app/javascript/styles/_navbar.scss
@@ -1,0 +1,231 @@
+// Tenjin Navbar — logged-out and logged-in variants
+// Visual reference: design/tenjin-design-system/project/ui_kits/web/Navbar.jsx
+// All colours via --tj-* tokens (04a). No Bootstrap component classes.
+
+.tj-navbar {
+  background: var(--tj-black);
+  min-height: 66px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 26px;
+  position: relative;
+  z-index: 1000;
+
+  &--fixed {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+  }
+}
+
+// Brand: icon + "Tenjin" wordmark
+.tj-navbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: var(--tj-white);
+
+  &:hover {
+    color: var(--tj-white);
+    text-decoration: none;
+  }
+
+  .fas {
+    font-size: 2rem;
+    color: var(--tj-white);
+  }
+}
+
+.tj-navbar__wordmark {
+  font-family: var(--tj-display);
+  font-weight: var(--tj-w-black);
+  font-size: var(--tj-size-h1);
+  text-transform: uppercase;
+  color: var(--tj-white);
+  line-height: 1;
+  // suppress default h1 margin when used inside a nav
+  margin: 0;
+}
+
+// Right-side links row (logged-in)
+.tj-navbar__links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+// Individual nav link / button
+.tj-navbar__link {
+  font-family: var(--tj-body);
+  font-weight: var(--tj-w-light);
+  font-size: 1rem;
+  color: var(--tj-light);
+  text-decoration: none;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  line-height: inherit;
+
+  &:hover {
+    color: var(--tj-light);
+    text-decoration: none;
+    opacity: 0.8;
+  }
+
+  &--active {
+    font-weight: var(--tj-w-black);
+  }
+}
+
+// Challenge-points pill (star + number)
+.tj-navbar__points {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--tj-light);
+  font-weight: var(--tj-w-light);
+  text-decoration: none;
+
+  &:hover {
+    color: var(--tj-light);
+    text-decoration: none;
+    opacity: 0.8;
+  }
+
+  .fas.fa-star {
+    color: var(--tj-yellow);
+  }
+}
+
+// Logged-in user's name
+.tj-navbar__user {
+  color: var(--tj-light);
+  font-family: var(--tj-body);
+  font-weight: var(--tj-w-light);
+  font-size: 0.9375rem;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      color: var(--tj-light);
+      text-decoration: none;
+      opacity: 0.8;
+    }
+  }
+}
+
+// Shop sub-menu dropdown (CSS hover on desktop; Stimulus on mobile)
+.tj-navbar__dropdown {
+  position: relative;
+
+  &:hover .tj-navbar__dropdown-menu,
+  &.tj-navbar__dropdown--open .tj-navbar__dropdown-menu {
+    display: block;
+  }
+}
+
+.tj-navbar__dropdown-toggle {
+  // inherits .tj-navbar__link styles; add visual cue
+  &::after {
+    content: " ▾";
+    font-size: 0.75em;
+  }
+}
+
+.tj-navbar__dropdown-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  background: var(--tj-white);
+  border-radius: var(--tj-radius);
+  min-width: 11rem;
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.2);
+  z-index: 1001;
+}
+
+.tj-navbar__dropdown-item {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: var(--tj-ink);
+  text-decoration: none;
+  font-family: var(--tj-body);
+  font-weight: var(--tj-w-light);
+  font-size: 1rem;
+
+  &:hover {
+    background: var(--tj-light);
+    color: var(--tj-ink);
+    text-decoration: none;
+  }
+}
+
+// Mobile hamburger toggler (hidden on ≥768px)
+.tj-navbar__toggler {
+  display: none;
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: var(--tj-radius);
+  padding: 6px 10px;
+  cursor: pointer;
+  color: var(--tj-light);
+  font-size: 1.25rem;
+  line-height: 1;
+
+  @media (max-width: 767px) {
+    display: block;
+  }
+}
+
+// Collapsible section — flex row on desktop, toggled column on mobile
+.tj-navbar__collapse {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+
+  @media (max-width: 767px) {
+    display: none;
+    flex-direction: column;
+    align-items: flex-start;
+    position: absolute;
+    top: 66px;
+    left: 0;
+    right: 0;
+    background: var(--tj-black);
+    padding: 1rem 1.5rem;
+    z-index: 999;
+    gap: 1rem;
+
+    &.tj-navbar__collapse--open {
+      display: flex;
+    }
+
+    // On mobile, dropdown menu is inline (no absolute positioning)
+    .tj-navbar__dropdown {
+      width: 100%;
+    }
+
+    .tj-navbar__dropdown-menu {
+      position: static;
+      box-shadow: none;
+      background: transparent;
+      padding-left: 1rem;
+    }
+
+    .tj-navbar__dropdown-item {
+      color: var(--tj-light);
+      padding: 0.25rem 0;
+
+      &:hover {
+        background: transparent;
+        opacity: 0.8;
+      }
+    }
+  }
+}

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -12,6 +12,7 @@
  *
  */
 @import 'tokens';
+@import 'navbar';
 
 @import url('https://fonts.googleapis.com/css?family=Raleway:300,900,900i');
 @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,900;1,400;1,900&display=swap');
@@ -25,10 +26,6 @@
 @import 'trix/dist/trix';
 @import 'leaderboard';
 @import 'shepherd';
-
-.navbar-dark .nav-item .nav-link {
-  color: theme-color("light");
-}
 
 a {
   color: #212529;
@@ -166,29 +163,8 @@ h1#branding-text {
   margin-bottom: 0rem;
 }
 
-#navbar-main.bg-black {
-  background-color: black;
-}
-
-#navbar-main {
-  background-color: transparent;
-  min-height: 66px;
-}
-
-#navbar-btn {  
-  @include media-breakpoint-up(md) {
-    font-size: 2rem;
-  }
-}
-
 h1, h3, #branding-text, .fa-2x {
   font-size: 2rem;
-
-}
-
-.navbar {
-  padding-top: 0.15rem;
-  padding-bottom: 0.15rem;
 }
 
 .form-control {

--- a/app/views/shared/_logged_out_navigation.html.slim
+++ b/app/views/shared/_logged_out_navigation.html.slim
@@ -1,7 +1,6 @@
-nav#navbar-main.navbar.navbar-expand-sm.navbar-dark.justify-content-between.fixed-top
-  a.navbar-brand href="/"
-    i.fas.fa-vihara.fa-2x style='color: white'
-    h1#branding-text.navbar-text.text-uppercase style="color:white"
-      | Tenjin
-  button.btn.btn-light-outline.my-1 data-toggle="modal" data-target="#studentLoginModal"
+nav#navbar-main.tj-navbar
+  a.tj-navbar__brand href="/"
+    i.fas.fa-vihara
+    span#branding-text.tj-navbar__wordmark Tenjin
+  button.tj-btn-outline-light data-toggle="modal" data-target="#studentLoginModal" type="button"
     | Login

--- a/app/views/shared/_user_navigation.html.slim
+++ b/app/views/shared/_user_navigation.html.slim
@@ -1,55 +1,35 @@
-nav#navbar-main.navbar.navbar-expand-md.navbar-dark.justify-content-between.bg-black
-  a href=dashboard_path
-    .navbar-brand
-      i.fas.fa-vihara.fa-2x.d-inline-block.align-middle style='color: White'
-      h1#branding-text.navbar-text.text-uppercase.align-middle style="color:white"
-        | Tenjin
-  button.navbar-toggler type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"
-      span.navbar-toggler-icon
+nav#navbar-main.tj-navbar data-controller="navbar"
+  a.tj-navbar__brand href=dashboard_path
+    i.fas.fa-vihara
+    span#branding-text.tj-navbar__wordmark Tenjin
 
-  #navbarSupportedContent.collapse.navbar-collapse 
-    ul.navbar-nav.mr-auto
-      li.nav-item
-        a.nav-link href=leaderboard_index_path
-          | Leaderboard  
-      - if current_user.student?
-        li.nav-item.dropdown.active
-          a.nav-link.dropdown-toggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-            | Shop
-          .dropdown-menu aria-labelledby='navbarDropdown'
-            a.dropdown-item href=show_available_customisations_path(anchor: 'dashboard-styles')
-              | Styles
-            a.dropdown-item href=show_available_customisations_path(anchor: 'icons')
-              | Leaderboard Icons 
-      li.nav-item
-        a.nav-link href=lessons_path
-          | Lessons     
-      - if current_user.employee?
-        li.nav-item
-          a.nav-link href=dashboard_path
-            | Classrooms
-        -if current_user.has_role? :school_admin
-          li.nav-item
-            a.nav-link href=users_path
-              | User Admin
-        -if current_user.has_role? :school_admin
-          li.nav-item
-            a.nav-link href=classrooms_path
-              | Setup Classrooms    
-        -if current_user.has_role? :question_author, :any
-          li.nav-item
-            a.nav-link href=topics_path
-              | Edit Questions      
+  button.tj-navbar__toggler type="button" aria-expanded="false" aria-label="Toggle navigation" data-action="click->navbar#toggle" data-navbar-target="toggler"
+    i.fas.fa-bars
 
-    -if current_user.student?
-      a href=show_available_customisations_path
-        table
-          td
-            i.fas.fa-star.f style='color: yellow'    
-          td#challenge-points.text-light = current_user.challenge_points          
-    p.m-2#current_user_paragraph
-      a#current_user.text-light href=user_path(current_user)
+  .tj-navbar__collapse data-navbar-target="menu"
+    - if current_user.student?
+      a.tj-navbar__link href=leaderboard_index_path Leaderboard
+      .tj-navbar__dropdown
+        button.tj-navbar__link.tj-navbar__dropdown-toggle type="button" data-action="click->navbar#toggleDropdown" Shop
+        .tj-navbar__dropdown-menu
+          a.tj-navbar__dropdown-item href=show_available_customisations_path(anchor: 'dashboard-styles') Styles
+          a.tj-navbar__dropdown-item href=show_available_customisations_path(anchor: 'icons') Leaderboard Icons
+      a.tj-navbar__link href=lessons_path Lessons
+    - if current_user.employee?
+      a.tj-navbar__link href=leaderboard_index_path Leaderboard
+      a.tj-navbar__link href=lessons_path Lessons
+      a.tj-navbar__link href=dashboard_path Classrooms
+      - if current_user.has_role? :school_admin
+        a.tj-navbar__link href=users_path User Admin
+        a.tj-navbar__link href=classrooms_path Setup Classrooms
+      - if current_user.has_role? :question_author, :any
+        a.tj-navbar__link href=topics_path Edit Questions
+    - if current_user.student?
+      a.tj-navbar__points href=show_available_customisations_path
+        i.fas.fa-star
+        span#challenge-points = current_user.challenge_points
+    span.tj-navbar__user
+      a#current_user href=user_path(current_user)
         => current_user.forename
         = current_user.surname
-    = button_to "Logout", destroy_user_session_path, method: :delete, class: "button btn btn-light-outline", data: {turbo: "false"}
-      
+    = button_to "Logout", destroy_user_session_path, method: :delete, class: "tj-btn-outline-light", data: {turbo: "false"}

--- a/spec/requests/pages_request_spec.rb
+++ b/spec/requests/pages_request_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe 'Pages', :default_creates, type: :request do
       expect(response.body).to include('About')
     end
 
-    it 'has a fixed top nav bar' do
+    it 'has a navbar' do
       html = Capybara.string(response.body)
-      expect(html).to have_css('nav.fixed-top')
+      expect(html).to have_css('nav.tj-navbar')
     end
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'Pages', :default_creates, type: :request do
 
     it 'has the logged out navigation on the about page' do
       html = Capybara.string(response.body)
-      expect(html).to have_css('nav.fixed-top')
+      expect(html).to have_css('nav.tj-navbar')
     end
   end
 

--- a/spec/system/customise/user_customises_the_site_spec.rb
+++ b/spec/system/customise/user_customises_the_site_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'User customises the site', :default_creates, :js, type: :system 
   context 'when visiting the customisation page from the navbar' do
     it 'visits from the customise link' do
       visit(dashboard_path)
-      find('a', text: 'Shop').click
+      find('button', text: 'Shop').click
       find('a', text: 'Styles').click
       expect(page).to have_current_path(show_available_customisations_path)
     end
@@ -57,7 +57,7 @@ RSpec.describe 'User customises the site', :default_creates, :js, type: :system 
 
     it 'deducts the required amount of challenge points' do
       find("form[action='#{buy_customisation_path(dashboard_customisation)}'] input.btn").click
-      expect(page).to have_css('td#challenge-points',
+      expect(page).to have_css('#challenge-points',
                                exact_text: student.challenge_points - dashboard_customisation.cost)
     end
 
@@ -112,7 +112,7 @@ RSpec.describe 'User customises the site', :default_creates, :js, type: :system 
         visit(show_available_customisations_path)
         find("form[action='#{buy_customisation_path(dashboard_customisation)}'] input.btn").click
         find('.alert', text: 'Congratulations!')
-        expect(page).to have_css('td#challenge-points',
+        expect(page).to have_css('#challenge-points',
                                  exact_text: student.challenge_points - dashboard_customisation.cost)
       end
     end

--- a/spec/system/customise/user_customises_the_site_spec.rb
+++ b/spec/system/customise/user_customises_the_site_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'User customises the site', :default_creates, :js, type: :system 
   context 'when visiting the customisation page from the navbar' do
     it 'visits from the customise link' do
       visit(dashboard_path)
-      find('button', text: 'Shop').click
+      click_button 'Shop'
       find('a', text: 'Styles').click
       expect(page).to have_current_path(show_available_customisations_path)
     end


### PR DESCRIPTION
Replaces the Bootstrap-classed navbar partials with a custom Slim + SCSS implementation using the Tenjin Design System tokens (--tj-*) from 04a.

Changes:
- New _navbar.scss: .tj-navbar, .tj-navbar__*, .tj-btn-outline-light via tokens; mobile-responsive collapse; CSS hover dropdown for Shop.
- navbar_controller.js (Stimulus): toggles mobile menu open/close and Shop dropdown on click; cleans up on outside-click.
- Logged-out nav: removes .navbar.navbar-dark.fixed-top; uses .tj-navbar. Login button keeps data-toggle="modal" (modal rebuilt in 04b surface 2).
- User nav: removes .navbar.navbar-expand-md et al; Stimulus data-controller replaces BS data-toggle="collapse"; Shop uses button + Stimulus dropdown instead of BS dropdown.
- pages.js: swaps fixed-top/bg-dark for tj-navbar--fixed/tj-navbar--dark.
- application.scss: imports _navbar.scss; removes #navbar-main / .navbar rules that are now superseded by token-based styles.
- Specs updated: nav.fixed-top → nav.tj-navbar; find('a', 'Shop') → find('button', 'Shop'); td#challenge-points → #challenge-points.

Admin nav unchanged (04d). Bootstrap grid kept (04c). BS modal kept for login button (04b surface 2). yarn build clean; suite at pre-existing 1 flaky failure.