### PR TITLE
frontend/04g: Remove Bootstrap classes from quiz surface

### DIFF
--- a/app/javascript/packs/questions/multiple_choice_question.js
+++ b/app/javascript/packs/questions/multiple_choice_question.js
@@ -27,7 +27,7 @@ function processMultipleChoiceResponse (serverResponse, guessId) {
 
   const nextBtn = document.getElementById('nextButton')
   if (nextBtn) {
-    nextBtn.classList.remove('invisible')
+    nextBtn.classList.remove('tj-invisible')
     nextBtn.focus()
   }
 }

--- a/app/javascript/packs/questions/short_response_question.js
+++ b/app/javascript/packs/questions/short_response_question.js
@@ -35,7 +35,7 @@ function processShortResponse (serverResponse, guess) {
 
   const nextBtn = document.getElementById('nextButton')
   if (nextBtn) {
-    nextBtn.classList.remove('invisible')
+    nextBtn.classList.remove('tj-invisible')
     nextBtn.focus()
   }
 }

--- a/app/javascript/styles/_quiz.scss
+++ b/app/javascript/styles/_quiz.scss
@@ -1,0 +1,100 @@
+// Quiz surface — design tokens only, no Bootstrap.
+// Covers: quizzes/show, _question_top, _question_bottom, _multiple_choice, _short_answer, select_topic.
+
+// ── Progress bar ───────────────────────────────────────────────────────────
+
+.tj-progress {
+  height: 0.5rem;
+  background: #dee2e6;
+  border-radius: var(--tj-radius-pill);
+  overflow: hidden;
+  margin-bottom: var(--tj-space-3);
+}
+
+.tj-progress__bar {
+  height: 100%;
+  background: var(--tj-red);
+  border-radius: var(--tj-radius-pill);
+  transition: width 0.3s ease;
+}
+
+// ── HUD bar (streak / correct / multiplier) ────────────────────────────────
+
+.tj-quiz-hud {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  flex-wrap: wrap;
+  padding-bottom: var(--tj-space-3);
+}
+
+.tj-quiz-hud__item {
+  display: flex;
+  align-items: center;
+  gap: var(--tj-space-2);
+  text-align: center;
+  padding: 0 var(--tj-space-3);
+}
+
+// ── Quiz body — optional lesson sidebar ───────────────────────────────────
+
+.tj-quiz-content {
+  display: flex;
+  align-items: center;
+  gap: var(--tj-space-3);
+  flex-wrap: wrap;
+}
+
+.tj-quiz-main {
+  flex: 1 1 60%;
+  min-width: 0;
+}
+
+.tj-quiz-lesson {
+  flex: 0 1 30%;
+  text-align: center;
+}
+
+.tj-lesson-thumb {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: var(--tj-radius);
+  margin: 0 auto;
+}
+
+// ── Question footer bar ─────────────────────────────────────────────────────
+
+.tj-quiz-footer {
+  padding-top: var(--tj-space-2);
+  padding-bottom: var(--tj-space-2);
+}
+
+.tj-quiz-footer__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--tj-space-3);
+}
+
+// ── Icon-only button (flag question) ───────────────────────────────────────
+
+.tj-btn-icon {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  line-height: 1;
+}
+
+// ── Warning notice (non-counting quiz) ─────────────────────────────────────
+
+.tj-quiz-warning {
+  max-width: 66%;
+  margin: var(--tj-space-2) auto;
+  padding: var(--tj-space-3);
+  background: var(--tj-warning-bg);
+  border: 1px solid var(--tj-warning-bd);
+  color: var(--tj-warning-fg);
+  border-radius: var(--tj-radius);
+}

--- a/app/javascript/styles/_tokens.scss
+++ b/app/javascript/styles/_tokens.scss
@@ -191,3 +191,6 @@ body, .tj-body {
 /* Answer states */
 .tj-answer-correct   { background: var(--tj-correct);   color: #fff; }
 .tj-answer-incorrect { background: var(--tj-incorrect); color: #fff; }
+
+/* Visibility toggle — replaces Bootstrap .invisible (keeps layout space) */
+.tj-invisible { visibility: hidden; }

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -18,6 +18,7 @@
 @import 'forms';
 @import 'layout';
 @import 'classroom';
+@import 'quiz';
 
 @import url('https://fonts.googleapis.com/css?family=Raleway:300,900,900i');
 @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,900;1,400;1,900&display=swap');

--- a/app/views/quizzes/_flagged_question_icon.html.slim
+++ b/app/views/quizzes/_flagged_question_icon.html.slim
@@ -1,16 +1,16 @@
-        
-        
-=turbo_frame_tag "unfairFlag"     
+
+
+=turbo_frame_tag "unfairFlag"
   =form_with url: flagged_questions_path(flagged_question: {user_id: current_user.id, question_id: @question.id }), class: "text-right" do |f|
     - if @flagged_question.present? && @flagged_question.persisted?
       =f.button"<img class='fas fa-flag' style='color: red'></img>".html_safe,
-        class: 'btn',
+        class: 'tj-btn-icon',
         alt: 'Flag unfair question',
         title:'Flag unfair question',
         onclick: "document.getElementById('feedbackModal').showModal()"
     - else
       =f.button"<img class='far fa-flag' style='color: red'></img>".html_safe,
-        class: 'btn',
+        class: 'tj-btn-icon',
         alt: 'Flag unfair question',
         title:'Flag unfair question',
         onclick: "document.getElementById('feedbackModal').showModal()"

--- a/app/views/quizzes/_multiple_choice.html.slim
+++ b/app/views/quizzes/_multiple_choice.html.slim
@@ -1,10 +1,10 @@
 div.lead.text-center ==@question.question_text
 -if @question.boolean?
   -@question.answers.order(text: :desc).each do |a|
-    button.btn.btn-dark.btn-block.m-2.question-button.multiple-choice-button id="response-#{a.id}"
+    button.tj-btn-dark.tj-btn--full.question-button.multiple-choice-button id="response-#{a.id}"
       = a.text
 -else
   -@question.answers.shuffle.each do |a|
-    button.btn.btn-dark.btn-block.m-2.question-button.multiple-choice-button id="response-#{a.id}"
+    button.tj-btn-dark.tj-btn--full.question-button.multiple-choice-button id="response-#{a.id}"
       = a.text
-button.btn.btn-dark.btn-block.m-2.next-button.invisible#nextButton onclick='location.reload()' Next Question
+button.tj-btn-dark.tj-btn--full.next-button.tj-invisible#nextButton onclick='location.reload()' Next Question

--- a/app/views/quizzes/_question_bottom.html.slim
+++ b/app/views/quizzes/_question_bottom.html.slim
@@ -1,16 +1,13 @@
-.container.py-2
-  .row
-    .col
-      -if @quiz.lesson.blank?
-        p#quiz-name=@question.topic.name
-      -else
-        p#quiz-name=@question.lesson.title
-    .col         
-      =render "flagged_question_icon"
-            
+.tjk-container.tj-quiz-footer
+  .tj-quiz-footer__bar
+    -if @quiz.lesson.blank?
+      p#quiz-name=@question.topic.name
+    -else
+      p#quiz-name=@question.lesson.title
+    =render "flagged_question_icon"
 
 -unless @quiz.counts_for_leaderboard
-  .row.col-lg-8.mx-auto.alert.alert-warning 
+  .tj-quiz-warning
     | This quiz is currently not counting towards your leaderboard points.  The first attempt at a lesson homework will count, or the first four quizzes for a particular topic.
 
 dialog#feedbackModal

--- a/app/views/quizzes/_question_top.html.slim
+++ b/app/views/quizzes/_question_top.html.slim
@@ -1,18 +1,13 @@
-.container.pt-5
-  .progress.mb-3
-    .progress-bar role="progressbar" style="width:#{@percent_complete}%" aria-valuenow="#{@percent_complete}" aria-valuemin="0" aria-valuemax="100"
-  .row.justify-content-around
-    .col-3.text-center
-      ul.list-inline
-        li.list-inline-item
-          i.fas.fa-bolt style='color:black' alt='Streak' title='Streak' data-toggle="tooltip"
-        li.list-inline-item#streak = @quiz.streak
-    .col-3.text-center
-      ul.list-inline
-        li.list-inline-item
-          i.fas.fa-check style='color:green' alt='Correct' title='Correct' data-toggle="tooltip"    
-        li.list-inline-item#answeredCorrect = @quiz.answered_correct
-    .col-3.text-center
-      ul.list-inline
-        li.list-inline-item#multiplier = @multiplier.multiplier
-        i.fas.fa-times style='color:blue' alt='Multiplier' title='Multiplier' data-toggle="tooltip"
+.tjk-container style='padding-top: var(--tj-space-5)'
+  .tj-progress
+    .tj-progress__bar role="progressbar" style="width:#{@percent_complete}%" aria-valuenow="#{@percent_complete}" aria-valuemin="0" aria-valuemax="100"
+  .tj-quiz-hud
+    .tj-quiz-hud__item
+      i.fas.fa-bolt style='color: var(--tj-streak)' alt='Streak' title='Streak'
+      span#streak = @quiz.streak
+    .tj-quiz-hud__item
+      i.fas.fa-check style='color: var(--tj-correct-icon)' alt='Correct' title='Correct'
+      span#answeredCorrect = @quiz.answered_correct
+    .tj-quiz-hud__item
+      span#multiplier = @multiplier.multiplier
+      i.fas.fa-times style='color: var(--tj-multiplier)' alt='Multiplier' title='Multiplier'

--- a/app/views/quizzes/_short_answer.html.slim
+++ b/app/views/quizzes/_short_answer.html.slim
@@ -1,4 +1,4 @@
 p.lead.text-center ==@question.question_text
-input.form-control.text-center.container-fluid.m-2#shortAnswerText autofocus='' autocomplete='off'
-button.btn.btn-dark.btn-block.m-2.question-button#shortAnswerButton Check Answer
-button.btn.btn-dark.btn-block.m-2.next-button.invisible#nextButton onclick='location.reload()' Next Question
+input.form-control.text-center#shortAnswerText autofocus='' autocomplete='off'
+button.tj-btn-dark.tj-btn--full.question-button#shortAnswerButton Check Answer
+button.tj-btn-dark.tj-btn--full.next-button.tj-invisible#nextButton onclick='location.reload()' Next Question

--- a/app/views/quizzes/select_topic.html.slim
+++ b/app/views/quizzes/select_topic.html.slim
@@ -7,4 +7,4 @@ section.page-section.text-center#newQuiz
     = simple_form_for(Quiz.new) do |f|
         = f.input :topic_id, label: 'Pick a topic:',as: :select, collection: @topics, include_blank: false
         = f.input :subject, as: :hidden, input_html: { value: @subject.id }
-        = f.button :submit, class: 'btn btn-dark'
+        = f.button :submit, class: 'tj-btn-dark'

--- a/app/views/quizzes/show.html.slim
+++ b/app/views/quizzes/show.html.slim
@@ -1,15 +1,15 @@
 -content_for :title
   title=('Quiz - ' + @quiz.subject.name)
 =render('question_top')
-.container
+.tjk-container
   -unless @lesson.blank? || @lesson.no_content?
-    .row.align-items-center
-      .col-md-8
+    .tj-quiz-content
+      .tj-quiz-main
         = render_question
-      .col-md-4.text-center#lesson
+      .tj-quiz-lesson#lesson
         h3.h3 = @lesson.title
         div.videoLink src=@lesson.generate_video_src
-          img.img-fluid.card-img-top video_id=@lesson.video_id category=@lesson.category src=@lesson.generate_thumbnail_src
+          img.tj-lesson-thumb video_id=@lesson.video_id category=@lesson.category src=@lesson.generate_thumbnail_src
   -else
     = render_question
 = render('question_bottom')

--- a/spec/system/quiz/user_takes_a_quiz_spec.rb
+++ b/spec/system/quiz/user_takes_a_quiz_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe 'User takes a quiz', :default_creates, :js, type: :system do
       it 'increases the percentage complete' do
         fill_in('shortAnswerText', with: correct_response).native.send_keys(:return)
         first(class: 'next-button').click
-        expect(find('.progress-bar')[:'aria-valuenow'].to_f).to be > 0
+        expect(find('.tj-progress__bar')[:'aria-valuenow'].to_f).to be > 0
       end
 
       it 'increases my streak if I am right' do


### PR DESCRIPTION
## Summary

- Replace Bootstrap classes in quiz views (`quizzes/`, `_question_top`, `_question_bottom`, `_multiple_choice`, `_short_answer`, `select_topic`) with token-backed `tj-*` utilities
- Add `_quiz.scss` partial: progress bar, HUD, lesson sidebar, footer bar, icon-only button, warning notice
- Replace `.invisible` → `.tj-invisible` in quiz views and JS (`multiple_choice_question.js`, `short_response_question.js`)
- Import `quiz` partial from `application.scss`

## Test plan

- [ ] 53 quiz system specs pass (`spec/system/quiz/`)
- [ ] `yarn build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)