### PR TITLE
frontend/04m: Remove Bootstrap classes from devise/login surface

### DIFF
--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -212,6 +212,15 @@ dialog::backdrop {
   width: 800px;
 }
 
+// Dialog inner layout — replaces Bootstrap .modal-content/.modal-body/.modal-footer
+.tj-dialog-content { display: flex; flex-direction: column; }
+.tj-dialog-header  { display: flex; justify-content: flex-end; padding: var(--tj-space-2) var(--tj-space-3); border-bottom: 1px solid #dee2e6; }
+.tj-dialog-body    { padding: var(--tj-space-4); }
+.tj-dialog-footer  { display: flex; justify-content: flex-end; gap: var(--tj-space-2); padding: var(--tj-space-3) var(--tj-space-4); border-top: 1px solid #dee2e6; }
+
+// Danger alert (replaces .alert.alert-danger)
+.tj-alert-danger { background: #f8d7da; border: 1px solid #f5c6cb; color: #721c24; border-radius: var(--tj-radius); padding: var(--tj-space-2) var(--tj-space-3); }
+
 // Sort indicators for table_controller.js
 thead th.sorted-asc::after  { content: ' ▲'; font-size: 0.7em; }
 thead th.sorted-desc::after { content: ' ▼'; font-size: 0.7em; }

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -212,6 +212,10 @@ dialog::backdrop {
   width: 800px;
 }
 
+#studentLoginModal {
+  width: 480px;
+}
+
 // Dialog inner layout — replaces Bootstrap .modal-content/.modal-body/.modal-footer
 .tj-dialog-content { display: flex; flex-direction: column; }
 .tj-dialog-header  { display: flex; justify-content: flex-end; padding: var(--tj-space-2) var(--tj-space-3); border-bottom: 1px solid #dee2e6; }

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -218,7 +218,7 @@ dialog::backdrop {
 
 // Dialog inner layout — replaces Bootstrap .modal-content/.modal-body/.modal-footer
 .tj-dialog-content { display: flex; flex-direction: column; }
-.tj-dialog-header  { display: flex; justify-content: flex-end; padding: var(--tj-space-2) var(--tj-space-3); border-bottom: 1px solid #dee2e6; }
+.tj-dialog-header  { display: flex; justify-content: flex-end; padding: var(--tj-space-2) var(--tj-space-3); }
 .tj-dialog-body    { padding: var(--tj-space-4); }
 .tj-dialog-footer  { display: flex; justify-content: flex-end; gap: var(--tj-space-2); padding: var(--tj-space-3) var(--tj-space-4); border-top: 1px solid #dee2e6; }
 

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -15,4 +15,4 @@ header.masthead.masthead-container.masthead-full.text-white
             input_html: { autocomplete: "new-password" }
           = f.input :password_confirmation, label: "Confirm your new password", required: true
         .form-actions
-          = f.button :submit, "Change my password", class: "btn btn-primary"
+          = f.button :submit, "Change my password", class: 'tj-btn-primary'

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -19,7 +19,7 @@ header.masthead.masthead-container.masthead-full.text-white
             input_html: { autocomplete: "current-password" }
           = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
         .form-actions
-          = f.button :submit, "Log in", class: 'btn btn-primary'
+          = f.button :submit, "Log in", class: 'tj-btn-primary'
       = render "devise/shared/links"
 footer.fixed-bottom.text-right.px-3.py-3.text-white
   =link_to 'About', page_path('about'), class: 'text-light'

--- a/app/views/pages/_student_login_modal.html.slim
+++ b/app/views/pages/_student_login_modal.html.slim
@@ -1,9 +1,9 @@
 dialog#studentLoginModal
-  .modal-content
-    .modal-header
-      button.close type='button' aria-label='Close' onclick='this.closest("dialog").close()'
+  .tj-dialog-content
+    .tj-dialog-header
+      button type='button' aria-label='Close' onclick='this.closest("dialog").close()' style='background:none; border:none; font-size:1.5rem; cursor:pointer; line-height:1'
         span aria-hidden='true' &times;
-    .modal-body
+    .tj-dialog-body
       =simple_form_for(resource, as: resource_name, data: { turbo: false }, url: session_path(resource_name)) do |f|
         .form-inputs
           = f.input :login,
@@ -14,8 +14,8 @@ dialog#studentLoginModal
               required: false,
               input_html: { autocomplete: "current-password" }
           = f.input :remember_me, as: :boolean, input_html: { checked: 'checked' } if devise_mapping.rememberable?
-          = f.button :submit, "Login", class: 'btn btn-primary btn-block', id: 'loginModal'
-      .my-3
+          = f.button :submit, "Login", class: 'tj-btn-primary tj-btn--full', id: 'loginModal'
+      div style='margin: var(--tj-space-3) 0; text-align: center'
         =button_to image_pack_tag('images/btn_google_signin_dark_normal_web.png'),
           user_google_oauth2_omniauth_authorize_path,
-          {data: {turbo: :false},class: 'd-flex mx-auto btn btn-outline', id: 'loginGoogle'}
+          {data: {turbo: :false}, style: 'display:flex; margin: 0 auto; background: none; border: none; cursor: pointer', id: 'loginGoogle'}

--- a/app/views/pages/home.slim
+++ b/app/views/pages/home.slim
@@ -4,12 +4,10 @@
   meta property="og:title" content="Tenjin"
   meta property="og:description" content="Quizzes: learn, compete, succeed!"
 
-header.masthead.masthead-container.masthead-full.text-white  
-  div.container.h-100
-    div.row.h-100.align-items-center
-      div.col.text-center
-        h1.section-heading.text-uppercase#mastheadText Learn, Compete, Succeed
-        hr.small.mb-5.primary-red
-footer.fixed-bottom.text-right.px-3.py-3.text-white 
+header.masthead.text-white style='display:flex; align-items:center; justify-content:center'
+  div.text-center
+    h1.section-heading.text-uppercase#mastheadText Learn, Compete, Succeed
+    hr.small.mb-5.primary-red
+footer.fixed-bottom.text-right.px-3.py-3.text-white
   = link_to 'About', page_path('about'), class: 'text-light'
 = render('student_login_modal')


### PR DESCRIPTION
## Summary

- Replace Bootstrap classes in Devise views (`devise/sessions/new`, `devise/passwords/edit`) with token-backed `tj-*` utilities
- Rework student login modal (`pages/_student_login_modal`) to use token-backed dialog layout
- Rework home page masthead (`pages/home`) to use flexbox inline style instead of Bootstrap grid
- Add global dialog utility classes (`tj-dialog-*`, `tj-alert-danger`) to `application.scss`
- 5 Devise/login system specs pass

## Test plan

- [ ] 5 Devise/login system specs pass (`spec/system/login/`)
- [ ] Login page renders correctly, student login modal opens
- [ ] `yarn build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)