### PR TITLE
04i Phase 0: add missing tj-* utility classes (Bootstrap-class sweep prerequisites)

### DIFF
--- a/app/javascript/styles/_utilities.scss
+++ b/app/javascript/styles/_utilities.scss
@@ -1,0 +1,92 @@
+// Tenjin utility classes — phase 04i-0
+// Replacements for Bootstrap utility classes used in views.
+// Phase 0 adds only the classes missing from existing tj-*/tjk-* helpers.
+
+// ── Layout ─────────────────────────────────────────────────────────────────
+
+// Full-width container (replaces Bootstrap .container-fluid)
+.tj-container-fluid {
+  width: 100%;
+  padding-left: var(--tj-space-3);
+  padding-right: var(--tj-space-3);
+}
+
+// ── Flex helpers ───────────────────────────────────────────────────────────
+
+.tj-flex             { display: flex; }
+.tj-justify-center   { justify-content: center; }
+.tj-justify-between  { justify-content: space-between; }
+.tj-items-center     { align-items: center; }
+
+// Horizontal centering (replaces Bootstrap .mx-auto)
+.tj-mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+// ── Typography ─────────────────────────────────────────────────────────────
+
+.tj-text-center { text-align: center; }
+.tj-text-right  { text-align: right; }
+
+// ── Alerts ─────────────────────────────────────────────────────────────────
+
+// Warning alert (replaces .alert.alert-warning)
+.tj-alert-warning {
+  background: var(--tj-warning-bg);
+  border: 1px solid var(--tj-warning-bd);
+  color: var(--tj-warning-fg);
+  border-radius: var(--tj-radius);
+  padding: var(--tj-space-2) var(--tj-space-3);
+}
+
+// Info alert (replaces .alert.alert-info)
+.tj-alert-info {
+  background: #d1ecf1;
+  border: 1px solid #bee5eb;
+  color: #0c5460;
+  border-radius: var(--tj-radius);
+  padding: var(--tj-space-2) var(--tj-space-3);
+}
+
+// Dismissible alert close button (replaces Bootstrap .close inside .alert-dismissible)
+.tj-alert-close {
+  float: right;
+  font-size: 1.25rem;
+  font-weight: var(--tj-w-black);
+  line-height: 1;
+  color: inherit;
+  opacity: 0.5;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 var(--tj-space-1);
+}
+.tj-alert-close:hover { opacity: 0.75; }
+
+// ── Accessibility ──────────────────────────────────────────────────────────
+
+// Screen-reader-only (replaces Bootstrap .sr-only)
+.tj-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// ── Responsive table-cell ──────────────────────────────────────────────────
+
+// Hidden at xs, shown as table-cell at ≥576px.
+// Replaces the two-class pattern .d-none.d-sm-table-cell on <td>/<th> elements.
+.tj-sm-table-cell {
+  display: none;
+
+  @media (min-width: 576px) {
+    display: table-cell;
+  }
+}

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -12,6 +12,7 @@
  *
  */
 @import 'tokens';
+@import 'utilities';
 @import 'layout';
 @import 'forms';
 @import 'navbar';


### PR DESCRIPTION
## Summary

- Adds `_utilities.scss` with 13 new utility classes required for Bootstrap-class swaps in 04i batches A–F
- Imports the new file in `application.scss` (right after `_tokens`)
- No view changes — CSS only; all class names verified unique against existing `tj-*/tjk-*` helpers
- `yarn build` green

### New classes added

| Class | Replaces Bootstrap |
|---|---|
| `tj-container-fluid` | `.container-fluid` |
| `tj-flex` | `.d-flex` |
| `tj-justify-center` | `.justify-content-center` |
| `tj-justify-between` | `.justify-content-between` |
| `tj-items-center` | `.align-items-center` |
| `tj-mx-auto` | `.mx-auto` |
| `tj-text-center` | `.text-center` |
| `tj-text-right` | `.text-right` |
| `tj-alert-warning` | `.alert.alert-warning` |
| `tj-alert-info` | `.alert.alert-info` |
| `tj-alert-close` | `.close` inside `.alert-dismissible` |
| `tj-sr-only` | `.sr-only` |
| `tj-sm-table-cell` | `.d-none.d-sm-table-cell` on `<td>`/`<th>` |

Already-existing classes reused by batches (not duplicated): `tj-hidden`, `tj-invisible`, `tj-hide-sm`, `tj-hide-md`, `tj-btn-primary`, `tj-btn-secondary`, `tj-btn--full`, `tj-card-body`, `tj-dialog-*`, `tj-alert-danger`, `tjk-container`.

## Test plan

- [ ] Visual smoke: pages still look correct with Bootstrap SCSS present (no regressions possible — only new class names added)
- [ ] `yarn build` passes (confirmed locally)
- [ ] No collision with existing `tj-*/tjk-*` class names (confirmed by grep)
- [ ] After merge, proceed to Batch A (`frontend/04i-a-student`) per plan 04i

🤖 Generated with [Claude Code](https://claude.com/claude-code)