### PR TITLE
feat: persist per-student attempt scoring foundations

### DIFF
--- a/app/jobs/update_question_statistics_job.rb
+++ b/app/jobs/update_question_statistics_job.rb
@@ -20,6 +20,7 @@ class UpdateQuestionStatisticsJob < ApplicationJob
     inactive_asked_questions.each do |q|
       unless q.correct.nil?
         increase_question_asked_count(q)
+        increase_student_statistic(q)
         increase_question_count_for_user(q)
       end
 
@@ -34,9 +35,33 @@ class UpdateQuestionStatisticsJob < ApplicationJob
     QuestionStatistic.upsert({ question_id: question.question_id,
                                number_asked: asked,
                                number_correct: correct,
+                               score_sum: calculate_score_sum(question),
                                created_at: now,
                                updated_at: now },
                              unique_by: :question_id)
+  end
+
+  # Additive upsert so repeated attempts on the same question accumulate.
+  STUDENT_STATISTIC_ON_DUPLICATE = Arel.sql(
+    'number_asked = student_question_statistics.number_asked + 1, ' \
+    'number_correct = student_question_statistics.number_correct + EXCLUDED.number_correct, ' \
+    'score_sum = student_question_statistics.score_sum + EXCLUDED.score_sum, ' \
+    'last_asked_at = EXCLUDED.last_asked_at, updated_at = EXCLUDED.updated_at'
+  ).freeze
+
+  # Persistent per-student-per-question rollup (survives the asked_question purge below).
+  def increase_student_statistic(asked_question)
+    now = Time.now
+    StudentQuestionStatistic.upsert(
+      { user_id: asked_question.quiz.user_id,
+        question_id: asked_question.question_id,
+        number_asked: 1,
+        number_correct: asked_question.correct? ? 1 : 0,
+        score_sum: attempt_score(asked_question),
+        last_asked_at: now, created_at: now, updated_at: now },
+      unique_by: %i[user_id question_id],
+      on_duplicate: STUDENT_STATISTIC_ON_DUPLICATE
+    )
   end
 
   def increase_question_count_for_user(question)
@@ -70,5 +95,18 @@ class UpdateQuestionStatisticsJob < ApplicationJob
     return 1 unless asked_question.question.question_statistic.present?
 
     asked_question.question.question_statistic.number_asked + 1
+  end
+
+  def calculate_score_sum(asked_question)
+    qs = asked_question.question.question_statistic
+    (qs.present? ? qs.score_sum : 0.0) + attempt_score(asked_question)
+  end
+
+  # Partial-credit score for this attempt. Falls back to correct/incorrect for legacy rows that
+  # predate the score column.
+  def attempt_score(asked_question)
+    return asked_question.score.to_f unless asked_question.score.nil?
+
+    asked_question.correct? ? 1.0 : 0.0
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,6 +5,7 @@ class Question < ApplicationRecord
   has_many :asked_questions, dependent: :destroy
   has_many :flagged_questions, dependent: :destroy
   has_many :quizzes, through: :asked_questions
+  has_many :student_question_statistics, dependent: :destroy
   has_one :question_statistic, dependent: :destroy
 
   belongs_to :lesson, optional: true, counter_cache: true

--- a/app/models/student_question_statistic.rb
+++ b/app/models/student_question_statistic.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Persistent per-student-per-question performance rollup. Survives the daily purge of
+# asked_questions (UpdateQuestionStatisticsJob) and underpins per-student gap analysis.
+class StudentQuestionStatistic < ApplicationRecord
+  belongs_to :user
+  belongs_to :question
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   has_many :classrooms, through: :enrollments
   has_many :subjects, through: :classrooms
   has_many :topic_scores
+  has_many :student_question_statistics, dependent: :destroy
   has_many :homeworks, through: :classrooms
 
   belongs_to :school

--- a/app/services/quiz/check_answer.rb
+++ b/app/services/quiz/check_answer.rb
@@ -65,12 +65,12 @@ class Quiz::CheckAnswer < ApplicationService
     @quiz.streak += 1
     # Best combo this run — display-only (results screen); does not affect scoring/outcomes.
     @quiz.max_streak = [@quiz.max_streak.to_i, @quiz.streak].max
-    @asked_question.update_attribute(:correct, true)
+    @asked_question.update(correct: true, score: 1.0)
     Quiz::AddLeaderboardPoint.call(quiz: @quiz, question: @question)
   end
 
   def process_incorrect_answer
     @quiz.streak = 0
-    @asked_question.update_attribute(:correct, false)
+    @asked_question.update(correct: false, score: 0.0)
   end
 end

--- a/db/migrate/20260621000400_add_scoring_columns.rb
+++ b/db/migrate/20260621000400_add_scoring_columns.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddScoringColumns < ActiveRecord::Migration[8.1]
+  def up
+    # Partial-credit score (0..1) for a single attempt, plus the raw student response so richer
+    # question types (drag-and-drop, matrix) can be re-scored / inspected. nil = legacy / unscored.
+    add_column :asked_questions, :score, :decimal, precision: 5, scale: 4
+    add_column :asked_questions, :response, :jsonb
+
+    # Running sum of partial-credit scores so difficulty can use mean score, not just correct count.
+    add_column :question_statistics, :score_sum, :float, default: 0.0, null: false
+
+    # Seed score_sum from the existing correct counts so difficulty has data on day one.
+    execute('UPDATE question_statistics SET score_sum = number_correct WHERE number_correct IS NOT NULL')
+  end
+
+  def down
+    remove_column :question_statistics, :score_sum
+    remove_column :asked_questions, :response
+    remove_column :asked_questions, :score
+  end
+end

--- a/db/migrate/20260621000500_create_student_question_statistics.rb
+++ b/db/migrate/20260621000500_create_student_question_statistics.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateStudentQuestionStatistics < ActiveRecord::Migration[8.1]
+  def change
+    # Persistent per-student-per-question rollup. asked_questions are purged daily by
+    # UpdateQuestionStatisticsJob, so this table is the durable record that powers per-student
+    # gap analysis (how a student does on specific questions, difficulty-weighted vs the cohort).
+    create_table :student_question_statistics do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :question, null: false, foreign_key: true
+      t.integer :number_asked, default: 0, null: false
+      t.integer :number_correct, default: 0, null: false
+      t.float :score_sum, default: 0.0, null: false
+      t.datetime :last_asked_at
+
+      t.timestamps
+    end
+
+    add_index :student_question_statistics, %i[user_id question_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_21_000300) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_21_000500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -134,6 +134,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_000300) do
     t.datetime "created_at", precision: nil, null: false
     t.bigint "question_id"
     t.bigint "quiz_id"
+    t.jsonb "response"
+    t.decimal "score", precision: 5, scale: 4
     t.datetime "updated_at", precision: nil, null: false
     t.index ["question_id"], name: "index_asked_questions_on_question_id"
     t.index ["quiz_id"], name: "index_asked_questions_on_quiz_id"
@@ -288,6 +290,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_000300) do
     t.integer "number_asked"
     t.integer "number_correct"
     t.bigint "question_id", null: false
+    t.float "score_sum", default: 0.0, null: false
     t.datetime "updated_at", null: false
     t.index ["question_id"], name: "index_question_statistics_on_question_id", unique: true
   end
@@ -479,6 +482,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_000300) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  create_table "student_question_statistics", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "last_asked_at"
+    t.integer "number_asked", default: 0, null: false
+    t.integer "number_correct", default: 0, null: false
+    t.bigint "question_id", null: false
+    t.float "score_sum", default: 0.0, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["question_id"], name: "index_student_question_statistics_on_question_id"
+    t.index ["user_id", "question_id"], name: "index_student_question_statistics_on_user_id_and_question_id", unique: true
+    t.index ["user_id"], name: "index_student_question_statistics_on_user_id"
+  end
+
   create_table "subjects", force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.datetime "created_at", precision: nil, null: false
@@ -620,6 +637,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_000300) do
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "student_question_statistics", "questions"
+  add_foreign_key "student_question_statistics", "users"
   add_foreign_key "topic_scores", "topics"
   add_foreign_key "topic_scores", "users"
   add_foreign_key "topics", "subjects"

--- a/db/seeds/development_questions.rb
+++ b/db/seeds/development_questions.rb
@@ -160,6 +160,7 @@ def seed_question_statistics
     QuestionStatistic.find_or_initialize_by(question:).tap do |stat|
       stat.number_asked = rand(20..500)
       stat.number_correct = stat.number_asked - rand(0..stat.number_asked)
+      stat.score_sum = stat.number_correct.to_f
       stat.save!
     end
   end

--- a/spec/factories/question_statistics.rb
+++ b/spec/factories/question_statistics.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :question_statistic do
     number_asked { rand(1..100) }
     number_correct { number_asked - rand(0..number_asked) }
+    score_sum { number_correct.to_f }
     question
   end
 end

--- a/spec/factories/student_question_statistics.rb
+++ b/spec/factories/student_question_statistics.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :student_question_statistic do
+    user factory: :student
+    question
+    number_asked { rand(1..50) }
+    number_correct { rand(0..number_asked) }
+    score_sum { number_correct.to_f }
+    last_asked_at { Time.current }
+  end
+end

--- a/spec/jobs/update_question_statistics_job_spec.rb
+++ b/spec/jobs/update_question_statistics_job_spec.rb
@@ -80,6 +80,50 @@ RSpec.describe UpdateQuestionStatisticsJob, :default_creates, type: :job do
     expect { described_class.perform_now }.to change(AskedQuestion, :count).by(-1)
   end
 
+  context 'when accumulating partial-credit score' do
+    it 'seeds score_sum from a correct attempt' do
+      asked_question
+      described_class.perform_now
+      expect(question_statistic.score_sum).to eq(1.0)
+    end
+
+    it 'uses the stored partial-credit score when present' do
+      create(:asked_question, question: question, correct: true, score: 0.5, quiz: quiz, user: student)
+      described_class.perform_now
+      expect(question_statistic.score_sum).to eq(0.5)
+    end
+
+    it 'adds to an existing score_sum' do
+      existing_statistic.update!(score_sum: 2.0)
+      asked_question
+      described_class.perform_now
+      expect { existing_statistic.reload }.to change(existing_statistic, :score_sum).by(1.0)
+    end
+  end
+
+  context 'when building the per-student rollup' do
+    it 'creates a student_question_statistic' do
+      asked_question
+      expect { described_class.perform_now }.to change(StudentQuestionStatistic, :count).by(1)
+    end
+
+    it 'records the attempt for the right student and question' do
+      asked_question
+      described_class.perform_now
+      stat = StudentQuestionStatistic.find_by(user: student, question: question)
+      expect(stat).to have_attributes(number_asked: 1, number_correct: 1, score_sum: 1.0)
+    end
+
+    it 'accumulates across attempts' do
+      create(:student_question_statistic, user: student, question: question,
+                                          number_asked: 3, number_correct: 2, score_sum: 2.0)
+      asked_question
+      described_class.perform_now
+      stat = StudentQuestionStatistic.find_by(user: student, question: question)
+      expect(stat).to have_attributes(number_asked: 4, number_correct: 3, score_sum: 3.0)
+    end
+  end
+
   context 'when the quiz is still active' do
     let(:quiz) { create(:quiz, active: true) }
 

--- a/spec/models/student_question_statistic_spec.rb
+++ b/spec/models/student_question_statistic_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StudentQuestionStatistic, type: :model do
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to belong_to(:question) }
+
+  it 'builds a valid record from the factory' do
+    expect(build(:student_question_statistic)).to be_valid
+  end
+end

--- a/spec/requests/quizzes_controller_spec.rb
+++ b/spec/requests/quizzes_controller_spec.rb
@@ -109,6 +109,30 @@ RSpec.describe 'using a quiz', :default_creates, type: :request do
     end
   end
 
+  describe 'scoring an answer' do
+    let(:sa_question) { create(:question, topic: topic, question_type: 'short_answer') }
+    let(:quiz) do
+      create(:new_quiz, user: student, question_order: [sa_question.id], counts_for_leaderboard: false,
+                        answered_correct: 0, streak: 0, max_streak: 0)
+    end
+    let(:asked_question) { create(:asked_question, quiz: quiz, question: sa_question) }
+
+    before do
+      sa_question.answers.first.update!(text: 'cat', correct: true)
+      asked_question
+    end
+
+    it 'stores a full score for a correct answer' do
+      patch quiz_path(id: quiz.id), params: { answer: { short_answer: 'cat' } }
+      expect(asked_question.reload.score).to eq(1.0)
+    end
+
+    it 'stores a zero score for an incorrect answer' do
+      patch quiz_path(id: quiz.id), params: { answer: { short_answer: 'dog' } }
+      expect(asked_question.reload.score).to eq(0.0)
+    end
+  end
+
   describe 'answering a question while a cosmetic trial is active' do
     let(:sa_question) { create(:question, topic: topic, question_type: 'short_answer') }
     let(:quiz) { create(:new_quiz, user: student, question_order: [sa_question.id]) }


### PR DESCRIPTION
Add partial-credit scoring (asked_questions.score/response, score_sum on question_statistics) and a durable per-student-per-question rollup (student_question_statistics) populated by UpdateQuestionStatisticsJob before the daily asked_question purge. This is the data foundation for difficulty-aware gap analysis.