### PR TITLE
feat: Add Analytics::QuestionDifficulty engine (gap-analysis branch 3)

### DIFF
--- a/app/services/analytics/question_difficulty.rb
+++ b/app/services/analytics/question_difficulty.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# One source of truth for "how hard is this question". Blends a per-question-type prior with the
+# empirical difficulty observed across the *whole* Tenjin cohort (all schools), shrinking toward the
+# prior until a question has been asked enough times to trust its own numbers. Partial-credit aware:
+# empirical difficulty comes from `score_sum` (0..1 per attempt), not just correct/incorrect.
+#
+#   Analytics::QuestionDifficulty.call(question)              # single question or id
+#   Analytics::QuestionDifficulty.call(Question.where(...))   # relation, one stats query
+#   Analytics::QuestionDifficulty.call([1, 2, 3])             # array of ids or questions
+#
+# Result:
+#   .difficulties => { question_id => { difficulty: 0.0..1.0, band: :easy|:medium|:hard }, ... }
+#   .difficulty / .band  are also set when called with a single question/id, for convenience.
+class Analytics::QuestionDifficulty < ApplicationService
+  # Type prior on the 0..1 difficulty scale, hardest-last. MCQ (`multiple`) carries a guessing floor
+  # so it reads easiest; free-recall `short_answer` is harder; the structured cloze / grid / ordering
+  # formats from the question-types overhaul are hardest. Used verbatim for unsampled questions and
+  # as the shrinkage target for lightly-sampled ones. These are deliberate judgement calls.
+  TYPE_PRIOR = {
+    'multiple' => 0.25,
+    'short_answer' => 0.45,
+    'fill_blank' => 0.55,
+    'ordering' => 0.60,
+    'drag_drop' => 0.70,
+    'matrix' => 0.70
+  }.freeze
+
+  # Prior for a question whose type has no entry above (e.g. the retired :boolean). Mid-scale so an
+  # unknown format is neither flattered nor punished.
+  DEFAULT_PRIOR = 0.40
+
+  # Empirical evidence overtakes the prior at this many attempts: weight = n / (n + K), so K is the
+  # sample size at which prior and reality are trusted 50/50. Deliberately conservative — a handful
+  # of attempts should not rebrand a question.
+  SHRINKAGE_K = 30
+
+  # Fixed cut points on the blended 0..1 score.
+  EASY_MAX = 0.34
+  MEDIUM_MAX = 0.67
+
+  def initialize(input)
+    super()
+    @input = input
+  end
+
+  def call
+    stats = stats_by_question_id
+    difficulties = questions.to_h do |question|
+      [question.id, difficulty_for(question, stats[question.id])]
+    end
+
+    result(success: true, difficulties: difficulties, **single_shortcuts(difficulties))
+  end
+
+  private
+
+  # Blend the type prior with the cohort-wide empirical difficulty, weighting empirical by sample
+  # size. Unsampled questions fall straight through to their prior.
+  def difficulty_for(question, stat)
+    prior = TYPE_PRIOR.fetch(question.question_type, DEFAULT_PRIOR)
+    blended = blend(prior, stat).clamp(0.0, 1.0)
+    { difficulty: blended, band: band_for(blended) }
+  end
+
+  # Sample-size-weighted blend of empirical difficulty toward the type prior. Falls through to the
+  # prior when the question has never been asked.
+  def blend(prior, stat)
+    asked = stat&.number_asked.to_i
+    return prior unless asked.positive?
+
+    empirical = 1.0 - (stat.score_sum.to_f / asked)
+    weight = asked.to_f / (asked + SHRINKAGE_K)
+    (weight * empirical) + ((1 - weight) * prior)
+  end
+
+  def band_for(difficulty)
+    if difficulty < EASY_MAX
+      :easy
+    elsif difficulty < MEDIUM_MAX
+      :medium
+    else
+      :hard
+    end
+  end
+
+  # Single query for every question in scope, keyed by question_id — no N+1 over the batch.
+  def stats_by_question_id
+    QuestionStatistic.where(question_id: questions.map(&:id)).index_by(&:question_id)
+  end
+
+  def questions
+    @questions ||= resolve_questions
+  end
+
+  def resolve_questions
+    case @input
+    when ActiveRecord::Relation then @input.to_a
+    when Question then [@input]
+    when Array then @input.first.is_a?(Question) ? @input : load_questions(@input)
+    else load_questions(@input)
+    end
+  end
+
+  def load_questions(ids)
+    Question.where(id: ids).to_a
+  end
+
+  # When called with a single question/id, promote that one result's keys to the top level so callers
+  # can read `.difficulty` / `.band` directly.
+  def single_shortcuts(difficulties)
+    return {} unless @input.is_a?(Question) || @input.is_a?(Integer)
+
+    difficulties.values.first || {}
+  end
+end

--- a/spec/services/analytics/question_difficulty_spec.rb
+++ b/spec/services/analytics/question_difficulty_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::QuestionDifficulty do
+  describe '.call' do
+    context 'with no statistics (prior only)' do
+      it 'uses the type prior verbatim for an unsampled question' do
+        question = create(:question, question_type: 'multiple')
+
+        outcome = described_class.call(question)
+
+        expect(outcome.difficulty).to eq(described_class::TYPE_PRIOR['multiple'])
+      end
+
+      it 'ranks the harder structured types above MCQ on the prior alone' do
+        # `build` (not `create`): the engine only reads question_type, so we skip the structured-
+        # config validation that real matrix questions require — it is irrelevant to difficulty.
+        mcq = build(:question, question_type: 'multiple')
+        matrix = build(:question, question_type: 'matrix')
+
+        expect(described_class.call(matrix).difficulty)
+          .to be > described_class.call(mcq).difficulty
+        expect(described_class.call(matrix).band).to eq(:hard)
+      end
+
+      it 'falls back to the default prior for a type with no entry' do
+        question = create(:question, question_type: 'multiple')
+        # Simulate the retired :boolean (enum value 1) that has no prior entry.
+        question.update_column(:question_type, 1)
+
+        outcome = described_class.call(question.reload)
+
+        expect(outcome.difficulty).to eq(described_class::DEFAULT_PRIOR)
+      end
+    end
+
+    context 'when the question is well sampled (empirical dominant)' do
+      it 'tracks the observed score, not the type prior' do
+        question = create(:question, question_type: 'multiple')
+        # 1000 attempts, 20% mean score => empirical difficulty 0.8, far from the 0.25 prior.
+        create(:question_statistic, question: question, number_asked: 1000,
+                                    number_correct: 200, score_sum: 200.0)
+
+        outcome = described_class.call(question)
+
+        expect(outcome.difficulty).to be_within(0.02).of(0.8)
+        expect(outcome.band).to eq(:hard)
+      end
+
+      it 'honours partial credit via score_sum rather than number_correct' do
+        question = create(:short_answer_question)
+        # Nobody is fully correct, but the cohort averages half marks => empirical difficulty 0.5.
+        create(:question_statistic, question: question, number_asked: 1000,
+                                    number_correct: 0, score_sum: 500.0)
+
+        expect(described_class.call(question).difficulty).to be_within(0.02).of(0.5)
+      end
+    end
+
+    context 'when shrinking by sample size' do
+      it 'sits halfway between empirical and prior at exactly K attempts' do
+        question = create(:question, question_type: 'multiple')
+        k = described_class::SHRINKAGE_K
+        # Empirical difficulty 1.0 (all wrong); prior 0.25; weight at n=K is 0.5.
+        create(:question_statistic, question: question, number_asked: k,
+                                    number_correct: 0, score_sum: 0.0)
+
+        expected = (0.5 * 1.0) + (0.5 * described_class::TYPE_PRIOR['multiple'])
+        expect(described_class.call(question).difficulty).to be_within(0.001).of(expected)
+      end
+
+      it 'stays near the prior when only lightly sampled' do
+        question = create(:question, question_type: 'multiple')
+        create(:question_statistic, question: question, number_asked: 1,
+                                    number_correct: 0, score_sum: 0.0)
+
+        # One brutal attempt should barely move a 0.25-prior MCQ.
+        expect(described_class.call(question).difficulty).to be < 0.35
+      end
+    end
+
+    context 'when classifying band boundaries' do
+      def difficulty_for_score(mean_score)
+        question = create(:question, question_type: 'multiple')
+        # Heavy sample so empirical dominates and difficulty ~= 1 - mean_score.
+        asked = 100_000
+        create(:question_statistic, question: question, number_asked: asked,
+                                    number_correct: 0, score_sum: mean_score * asked)
+        described_class.call(question)
+      end
+
+      it 'classifies low difficulty as easy' do
+        expect(difficulty_for_score(0.9).band).to eq(:easy)   # difficulty ~0.1
+      end
+
+      it 'classifies mid difficulty as medium' do
+        expect(difficulty_for_score(0.5).band).to eq(:medium) # difficulty ~0.5
+      end
+
+      it 'classifies high difficulty as hard' do
+        expect(difficulty_for_score(0.1).band).to eq(:hard)   # difficulty ~0.9
+      end
+    end
+
+    context 'with batch input' do
+      it 'returns a hash keyed by question id' do
+        easy = create(:question, question_type: 'multiple')
+        hard = create(:short_answer_question)
+
+        outcome = described_class.call([easy.id, hard.id])
+
+        expect(outcome.difficulties.keys).to contain_exactly(easy.id, hard.id)
+        expect(outcome.difficulties[hard.id][:difficulty])
+          .to be > outcome.difficulties[easy.id][:difficulty]
+      end
+
+      it 'loads statistics in a single query (no N+1)' do
+        questions = create_list(:question, 3, question_type: 'multiple')
+        questions.each { |q| create(:question_statistic, question: q) }
+
+        relation = Question.where(id: questions.map(&:id))
+
+        stats_queries = 0
+        counter = lambda do |_name, _start, _finish, _id, payload|
+          stats_queries += 1 if payload[:sql].include?('question_statistics')
+        end
+
+        ActiveSupport::Notifications.subscribed(counter, 'sql.active_record') do
+          described_class.call(relation)
+        end
+
+        expect(stats_queries).to eq(1)
+      end
+
+      it 'accepts an ActiveRecord relation' do
+        question = create(:question, question_type: 'multiple')
+
+        outcome = described_class.call(Question.where(id: question.id))
+
+        expect(outcome.difficulties).to have_key(question.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
One source of truth for question difficulty, blending a per-question-type prior with the cohort-wide empirical difficulty (1 - score_sum/number_asked from question_statistics, partial-credit aware). Empirical evidence is shrunk toward the type prior by sample size (weight = n / (n + K)), so new questions rank by type and well-sampled questions rank by reality. Returns a 0..1 difficulty plus :easy/:medium/:hard band, batch-friendly (one stats query keyed by question_id) for the upcoming gap report to consume.