### PR TITLE
feat: Implement student gap analysis feature

### DIFF
--- a/app/assets/stylesheets/_gap_analysis.scss
+++ b/app/assets/stylesheets/_gap_analysis.scss
@@ -1,0 +1,158 @@
+// Teacher gap-analysis surfaces (classrooms#gaps / #student_gap). Difficulty-aware, cohort-relative
+// reporting built on the Tenjin design system — no Bootstrap, no JS build step.
+
+.tj-gap {
+  padding-bottom: var(--tj-space-5);
+
+  &-header {
+    text-align: center;
+    margin: var(--tj-space-4) 0 var(--tj-space-3);
+  }
+
+  &-subtitle {
+    color: var(--tj-grey);
+    margin: var(--tj-space-1) 0 var(--tj-space-2);
+  }
+
+  &-note {
+    color: var(--tj-grey);
+    font-size: 0.9rem;
+    margin-bottom: var(--tj-space-3);
+  }
+
+  &-empty {
+    color: var(--tj-grey);
+    font-style: italic;
+  }
+
+  // Summary / engagement metric cards
+  &-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--tj-space-3);
+    margin-bottom: var(--tj-space-4);
+  }
+
+  &-card {
+    flex: 1 1 8rem;
+    display: flex;
+    flex-direction: column;
+    gap: var(--tj-space-1);
+    padding: var(--tj-space-3);
+    background: var(--tj-light);
+    border: 1px solid #e0e0e0;
+    border-radius: var(--tj-radius-lg);
+    text-align: center;
+  }
+
+  &-card-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--tj-grey);
+  }
+
+  // Hover/focus tooltip marker beside a metric-card label. The bubble is a CSS ::after fed by the
+  // data-tooltip attribute, so it shows instantly and styled (native title is too slow/unstyled).
+  &-info {
+    position: relative;
+    cursor: help;
+    font-size: 0.8rem;
+    color: var(--tj-grey);
+
+    &::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      bottom: calc(100% + 0.5rem);
+      left: 50%;
+      transform: translateX(-50%);
+      width: max-content;
+      max-width: 15rem;
+      padding: var(--tj-space-2) var(--tj-space-3);
+      background: var(--tj-ink);
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 400;
+      line-height: 1.35;
+      text-transform: none;
+      letter-spacing: normal;
+      text-align: left;
+      border-radius: var(--tj-radius);
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.12s ease;
+      z-index: 30;
+      pointer-events: none;
+    }
+
+    &:hover::after,
+    &:focus-visible::after {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--tj-grey);
+      outline-offset: 2px;
+    }
+  }
+
+  &-card-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--tj-ink);
+  }
+
+  // Topic heatmap grid
+  &-heatmap {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+    gap: var(--tj-space-2);
+  }
+
+  &-heat-cell {
+    display: flex;
+    flex-direction: column;
+    gap: var(--tj-space-1);
+    padding: var(--tj-space-3);
+    border-radius: var(--tj-radius);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+  }
+
+  &-heat-topic { font-weight: 700; color: var(--tj-ink); }
+  &-heat-score { font-size: 1.4rem; font-weight: 700; color: var(--tj-ink); }
+  &-heat-meta  { font-size: 0.78rem; color: var(--tj-theme-meta); }
+
+  // Difficulty band chips
+  &-band {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: var(--tj-radius-pill);
+    font-size: 0.78rem;
+    font-weight: 700;
+
+    &--easy   { background: #d4edda; color: #155724; }
+    &--medium { background: var(--tj-warning-bg); color: var(--tj-warning-fg); }
+    &--hard   { background: #f8d7da; color: #721c24; }
+  }
+
+  // Cohort standing chips
+  &-standing {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: var(--tj-radius-pill);
+    font-size: 0.78rem;
+    font-weight: 700;
+
+    &--above   { background: #d4edda; color: #155724; }
+    &--on_par  { background: var(--tj-light); color: var(--tj-theme-meta); }
+    &--below   { background: #f8d7da; color: #721c24; }
+    &--unknown { background: var(--tj-light); color: var(--tj-grey); }
+  }
+}
+
+// Entry point button on the classroom show page
+.tj-gap-link {
+  margin-bottom: var(--tj-space-3);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,6 +25,7 @@ textarea {
 @import 'forms';
 @import 'navbar';
 @import 'classroom';
+@import 'gap_analysis';
 @import 'admin';
 @import 'customisations';
 @import 'lessons';

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -2,7 +2,7 @@
 
 class ClassroomsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_classroom, only: %i[show update]
+  before_action :set_classroom, only: %i[show update gaps student_gap]
 
   def index
     authorize current_user.school, :sync?
@@ -26,6 +26,17 @@ class ClassroomsController < ApplicationController
     authorize @classroom
     @classroom.update(subject_id: update_classroom_params[:subject])
     @classroom.school.update(sync_status: 'needed')
+  end
+
+  def gaps
+    authorize @classroom, :gaps?
+    @report = Analytics::ClassGapReport.call(@classroom)
+  end
+
+  def student_gap
+    authorize @classroom, :gaps?
+    @student = @classroom.users.find(params.expect(:student_id))
+    @report = Analytics::StudentGapReport.call(@student, @classroom)
   end
 
   private

--- a/app/helpers/classrooms_helper.rb
+++ b/app/helpers/classrooms_helper.rb
@@ -36,6 +36,45 @@ module ClassroomsHelper
     "#{homework.completed_count} / #{homework.count} - #{percent}"
   end
 
+  # --- Gap analysis presentation -------------------------------------------------------------------
+
+  # A metric-card label with a hover/focus tooltip explaining the term. The trailing ⓘ marker reveals
+  # the explanation via a CSS tooltip (data-tooltip drives the ::after bubble); keyboard-focusable and
+  # mirrored into title/aria-label so it isn't mouse-only.
+  def gap_card_label(text, explanation)
+    tag.span(class: 'tj-gap-card-label') do
+      safe_join([text, ' ',
+                 tag.span('ⓘ', class: 'tj-gap-info', tabindex: 0, role: 'note',
+                               'data-tooltip': explanation, title: explanation, 'aria-label': explanation)])
+    end
+  end
+
+  # A 0..1 score as a whole-number percentage; em dash for "no data" (nil).
+  def gap_percent(score)
+    return '—' if score.nil?
+
+    number_to_percentage(score * 100, precision: 0)
+  end
+
+  # Difficulty band as a coloured chip (easy/medium/hard from Analytics::QuestionDifficulty).
+  def difficulty_band_chip(band)
+    return '' if band.nil?
+
+    tag.span(band.to_s.capitalize, class: "tj-gap-band tj-gap-band--#{band}")
+  end
+
+  # Cohort standing as a coloured chip (above / on_par / below / unknown).
+  def standing_chip(standing)
+    labels = { above: 'Above average', on_par: 'On par', below: 'Below average', unknown: 'No data' }
+    tag.span(labels.fetch(standing, 'No data'), class: "tj-gap-standing tj-gap-standing--#{standing}")
+  end
+
+  # Heatmap cell tint: low mean score => hot (red), high => cool (green). Drives the topic heatmap.
+  def heat_style(score)
+    hue = (score.to_f * 120).round # 0 = red, 120 = green
+    "background:hsl(#{hue},70%,88%)"
+  end
+
   def sync_button
     link_to 'Sync Classrooms & Users', sync_school_path(current_user.school),
             data: { turbo_method: :patch },

--- a/app/policies/classroom_policy.rb
+++ b/app/policies/classroom_policy.rb
@@ -5,6 +5,13 @@ class ClassroomPolicy < ApplicationPolicy
     user.employee?
   end
 
+  # Gap analysis exposes per-student performance, so it is scoped to the teacher's own school —
+  # tighter than #show. The student-drill action additionally loads the pupil through the
+  # classroom's enrolments, so a teacher cannot reach a pupil outside the class.
+  def gaps?
+    user.employee? && @record.school == user.school
+  end
+
   def update?
     user.has_role?(:school_admin) && @record.school == user.school
   end

--- a/app/services/analytics/class_gap_report.rb
+++ b/app/services/analytics/class_gap_report.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+# Difficulty-aware, cohort-relative gap analysis for a whole classroom — the flagship teacher surface
+# from the monetisation plan. Answers: where is this class weak, which questions trip them up, how do
+# they stand against every other Tenjin student on the *same* items (difficulty-weighted, not raw %),
+# and who is actually practising.
+#
+# Reads the durable per-student rollup (`student_question_statistics`) joined through the classroom's
+# enrolled students, scoped to the classroom subject's active topics. Every aggregate is a SQL
+# `GROUP BY` — never a query per student. The global baseline is `question_statistics`; question
+# hardness comes from `Analytics::QuestionDifficulty`.
+#
+#   report = Analytics::ClassGapReport.call(classroom)
+#   report.topic_heatmap           # [{ topic_id:, topic_name:, mean_score:, attempts:, students: }, ...] weakest first
+#   report.hardest_questions       # [{ question_id:, topic_id:, topic_name:, question_type:,
+#                                  #    difficulty:, band:, class_mean_score:, attempts: }, ...]
+#   report.cohort_comparison       # { overall: { mastery:, cohort_mastery:, delta:, standing: },
+#                                  #   by_topic: [ <overall keys> + topic_id:, topic_name:, ... ] }
+#   report.engagement              # { students_active:, quizzes_started:, questions_answered:,
+#                                  #   per_student: [{ user_id:, name:, quizzes_started:,
+#                                  #                   questions_answered:, last_active_at: }, ...] }
+class Analytics::ClassGapReport < ApplicationService
+  include Analytics::GapReportSupport
+
+  # The class summary card (the marketing/case-study asset) only needs the worst few questions.
+  HARDEST_QUESTIONS_LIMIT = 10
+
+  def initialize(classroom)
+    super()
+    @classroom = classroom
+  end
+
+  def call
+    result(
+      success: true,
+      classroom: @classroom,
+      student_count: student_ids.size,
+      topic_heatmap: topic_heatmap,
+      hardest_questions: hardest_questions,
+      cohort_comparison: cohort_comparison,
+      engagement: engagement
+    )
+  end
+
+  private
+
+  # Per-question class aggregates — the question universe every other section is built from.
+  def report_question_stats
+    @report_question_stats ||= compute_report_question_stats
+  end
+
+  def compute_report_question_stats
+    return {} if student_ids.empty? || topic_ids.empty?
+
+    StudentQuestionStatistic.joins(:question)
+                            .where(user_id: student_ids, questions: { topic_id: topic_ids })
+                            .group(:question_id)
+                            .pluck(:question_id, Arel.sql('SUM(score_sum)'), Arel.sql('SUM(number_asked)'))
+                            .to_h { |qid, score_sum, asked| [qid, stat_row(score_sum, asked)] }
+  end
+
+  def student_ids
+    @student_ids ||= User.where(role: 'student')
+                         .joins(:enrollments)
+                         .where(enrollments: { classroom_id: @classroom.id })
+                         .pluck(:id)
+  end
+
+  # Class mean score per topic, weakest first.
+  def topic_heatmap
+    return [] if student_ids.empty? || topic_ids.empty?
+
+    topic_heatmap_rows.map { |row| heatmap_entry(row) }.sort_by { |topic| topic[:mean_score] }
+  end
+
+  def topic_heatmap_rows
+    StudentQuestionStatistic.joins(question: :topic)
+                            .where(user_id: student_ids, topics: { id: topic_ids })
+                            .group('topics.id', 'topics.name')
+                            .pluck('topics.id', 'topics.name', Arel.sql('SUM(score_sum)'),
+                                   Arel.sql('SUM(number_asked)'), Arel.sql('COUNT(DISTINCT user_id)'))
+  end
+
+  # Row columns: [topic_id, topic_name, SUM(score_sum), SUM(number_asked), COUNT(DISTINCT user_id)].
+  def heatmap_entry(row)
+    { topic_id: row[0], topic_name: row[1], mean_score: mean(row[2], row[3]),
+      attempts: row[3].to_i, students: row[4].to_i }
+  end
+
+  # The questions the class found hardest (by cohort difficulty), with the class's own mean on each.
+  def hardest_questions
+    report_question_stats.keys
+                         .sort_by { |qid| -(difficulties.dig(qid, :difficulty) || 0.0) }
+                         .first(HARDEST_QUESTIONS_LIMIT)
+                         .map { |qid| hardest_question_row(qid) }
+  end
+
+  def hardest_question_row(qid)
+    stat = report_question_stats[qid]
+    question_descriptor(qid).merge(class_mean_score: mean(stat[:score_sum], stat[:asked]), attempts: stat[:asked])
+  end
+
+  # Who is actually practising. Quizzes-started comes from usage_statistics (written live on quiz
+  # start); answered-question counts come from the durable student_question_statistics rollup — the
+  # same source the rest of the report uses — because usage_statistics.questions_answered is not
+  # populated. Scoped to this subject's topics.
+  def engagement
+    rows = engagement_per_student
+    { students_active: rows.size,
+      quizzes_started: rows.sum { |entry| entry[:quizzes_started] },
+      questions_answered: rows.sum { |entry| entry[:questions_answered] },
+      per_student: rows }
+  end
+
+  def engagement_per_student
+    return [] if student_ids.empty? || topic_ids.empty?
+
+    answered = answered_by_student
+    quizzes = quizzes_by_student
+    (answered.keys | quizzes.keys).map { |uid| engagement_entry(uid, answered[uid], quizzes[uid]) }
+                                  .sort_by { |entry| -entry[:questions_answered] }
+  end
+
+  # Answered-question totals per student from the durable rollup: { user_id => { questions_answered:,
+  # last_active_at: } }.
+  def answered_by_student
+    StudentQuestionStatistic.joins(:question)
+                            .where(user_id: student_ids, questions: { topic_id: topic_ids })
+                            .group(:user_id)
+                            .pluck(:user_id, Arel.sql('SUM(number_asked)'), Arel.sql('MAX(last_asked_at)'))
+                            .to_h { |uid, asked, last| [uid, { questions_answered: asked.to_i, last_active_at: last }] }
+  end
+
+  # Quizzes-started totals per student from usage_statistics: { user_id => { quizzes_started:,
+  # last_active_at: } }.
+  def quizzes_by_student
+    UsageStatistic.where(user_id: student_ids, topic_id: topic_ids)
+                  .group(:user_id)
+                  .pluck(:user_id, Arel.sql('SUM(quizzes_started)'), Arel.sql('MAX(date)'))
+                  .to_h { |uid, started, date| [uid, { quizzes_started: started.to_i, last_active_at: date }] }
+  end
+
+  def engagement_entry(uid, answered, quizzes)
+    answered ||= {}
+    quizzes ||= {}
+    { user_id: uid, name: student_names[uid],
+      quizzes_started: quizzes[:quizzes_started].to_i,
+      questions_answered: answered[:questions_answered].to_i,
+      last_active_at: [answered[:last_active_at], quizzes[:last_active_at]].compact.max }
+  end
+
+  def student_names
+    @student_names ||= User.where(id: student_ids)
+                           .pluck(:id, :forename, :surname)
+                           .to_h { |id, forename, surname| [id, "#{forename} #{surname}"] }
+  end
+end

--- a/app/services/analytics/gap_report_support.rb
+++ b/app/services/analytics/gap_report_support.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# Shared aggregation helpers for the difficulty-aware gap reports (`ClassGapReport`,
+# `StudentGapReport`). Both reports judge performance against the *whole* Tenjin cohort on the same
+# items, weighting each question by `Analytics::QuestionDifficulty`. The host service defines the
+# question universe via `report_question_stats` (a `{ question_id => { score_sum:, asked: } }` hash);
+# everything else — difficulties, the global baseline, per-question metadata, difficulty-weighted
+# mastery and cohort standing — is derived here so the two reports stay consistent.
+module Analytics::GapReportSupport
+  # Difficulty-weighted mastery within this band of the global cohort reads as "on par"; beyond it,
+  # above/below. Deliberately generous so small classes are not over-labelled by noise.
+  STANDING_THRESHOLD = 0.05
+
+  private
+
+  # The classroom whose subject defines the topic scope. Both hosts hold it in @classroom.
+  def classroom
+    @classroom
+  end
+
+  def topics
+    @topics ||= classroom&.subject ? classroom.subject.topics.where(active: true).to_a : []
+  end
+
+  def topic_ids
+    @topic_ids ||= topics.map(&:id)
+  end
+
+  def topic_names
+    @topic_names ||= topics.to_h { |topic| [topic.id, topic.name] }
+  end
+
+  # The questions this report covers — defined by the host's `report_question_stats`.
+  def question_ids
+    report_question_stats.keys
+  end
+
+  # Hardness per question, from the cohort-wide difficulty engine. One stats query for the batch.
+  def difficulties
+    @difficulties ||= Analytics::QuestionDifficulty.call(question_ids).difficulties
+  end
+
+  # Global (all-school) baseline performance, keyed by question id. The cohort we compare against.
+  def global_question_stats
+    @global_question_stats ||= QuestionStatistic.where(question_id: question_ids)
+                                                .pluck(:question_id, :score_sum, :number_asked)
+                                                .to_h { |qid, score_sum, asked| [qid, stat_row(score_sum, asked)] }
+  end
+
+  def question_meta
+    @question_meta ||= Question.where(id: question_ids)
+                               .pluck(:id, :topic_id, :question_type)
+                               .to_h { |id, topic_id, type| [id, { topic_id: topic_id, question_type: type }] }
+  end
+
+  # The shared per-question payload every report row carries: where it sits and how hard it is.
+  def question_descriptor(qid)
+    meta = question_meta[qid] || {}
+    diff = difficulties[qid] || {}
+    { question_id: qid, topic_id: meta[:topic_id], topic_name: topic_names[meta[:topic_id]],
+      question_type: type_name(meta[:question_type]), difficulty: diff[:difficulty], band: diff[:band] }
+  end
+
+  # Difficulty-weighted mean score (0..1) over `qids`, drawing per-question means from `source`.
+  # Harder questions pull proportionally more weight; nil when nothing in scope was attempted.
+  def mastery(qids, source)
+    weighted = 0.0
+    weight = 0.0
+    qids.each do |qid|
+      difficulty = difficulties.dig(qid, :difficulty)
+      stat = source[qid]
+      next unless difficulty && stat && stat[:asked].positive?
+
+      weighted += (stat[:score_sum] / stat[:asked]) * difficulty
+      weight += difficulty
+    end
+    weight.positive? ? (weighted / weight).round(4) : nil
+  end
+
+  # Difficulty-weighted standing versus the global cohort, overall and per topic (weakest first).
+  # Both reports share this shape; the host supplies the question universe via report_question_stats.
+  def cohort_comparison
+    by_topic = report_question_stats.keys
+                                    .group_by { |qid| question_meta.dig(qid, :topic_id) }
+                                    .map { |topic_id, qids| topic_comparison(topic_id, qids) }
+                                    .sort_by { |entry| entry[:mastery] || 1.0 }
+    { overall: comparison(report_question_stats.keys, report_question_stats), by_topic: by_topic }
+  end
+
+  def topic_comparison(topic_id, qids)
+    comparison(qids, report_question_stats).merge(topic_id: topic_id, topic_name: topic_names[topic_id])
+  end
+
+  # An entity's difficulty-weighted standing over `qids` versus the global cohort.
+  def comparison(qids, source)
+    own = mastery(qids, source)
+    cohort = mastery(qids, global_question_stats)
+    delta = own && cohort ? (own - cohort).round(4) : nil
+    { mastery: own, cohort_mastery: cohort, delta: delta, standing: standing(delta) }
+  end
+
+  def standing(delta)
+    return :unknown if delta.nil?
+    return :above if delta > STANDING_THRESHOLD
+    return :below if delta < -STANDING_THRESHOLD
+
+    :on_par
+  end
+
+  def mean(score_sum, asked)
+    asked.to_i.positive? ? (score_sum.to_f / asked).round(4) : 0.0
+  end
+
+  def stat_row(score_sum, asked)
+    { score_sum: score_sum.to_f, asked: asked.to_i }
+  end
+
+  # Raw enum integers come back from grouped SQL; map them to the human type name.
+  def type_name(type)
+    return if type.nil?
+
+    Question.question_types.key(type) || type.to_s
+  end
+end

--- a/app/services/analytics/student_gap_report.rb
+++ b/app/services/analytics/student_gap_report.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# Per-student drill-down behind the class gap analysis. Same difficulty-weighted, cohort-relative
+# lens as `Analytics::ClassGapReport`, narrowed to one student: their topic strengths and gaps, how
+# they stand against the whole Tenjin cohort, and — most actionably — the questions they got wrong
+# that most of the cohort got right (priority gaps) and the hard questions they nonetheless aced
+# (strengths). The classroom supplies the subject/topic scope.
+#
+#   report = Analytics::StudentGapReport.call(user, classroom)
+#   report.topic_breakdown   # [{ topic_id:, topic_name:, mean_score:, attempts: }, ...] weakest first
+#   report.cohort_comparison # { overall: { mastery:, cohort_mastery:, delta:, standing: }, by_topic: [...] }
+#   report.priority_gaps     # [<question_descriptor> + student_score:, cohort_score:, gap:] biggest gap first
+#   report.strengths         # [<question_descriptor> + student_score:, cohort_score:] hardest-aced first
+class Analytics::StudentGapReport < ApplicationService
+  include Analytics::GapReportSupport
+
+  PRIORITY_LIMIT = 10
+  # A question only counts as a "strength" worth surfacing when the student scores at least this and
+  # the item is not an easy one — beating an easy question is not noteworthy.
+  STRENGTH_MIN_SCORE = 0.8
+  # A priority gap is a question the student got wrong that *most of the cohort got right*: it only
+  # qualifies once the cohort itself clears this bar, so shared-struggle questions are not flagged.
+  COHORT_COMPETENCE = 0.6
+
+  def initialize(user, classroom)
+    super()
+    @user = user
+    @classroom = classroom
+  end
+
+  def call
+    result(
+      success: true,
+      user: @user,
+      classroom: @classroom,
+      topic_breakdown: topic_breakdown,
+      cohort_comparison: cohort_comparison,
+      priority_gaps: priority_gaps,
+      strengths: strengths
+    )
+  end
+
+  private
+
+  # This student's per-question performance across the subject — the report's question universe.
+  def report_question_stats
+    @report_question_stats ||= compute_report_question_stats
+  end
+
+  def compute_report_question_stats
+    return {} if topic_ids.empty?
+
+    StudentQuestionStatistic.joins(:question)
+                            .where(user_id: @user.id, questions: { topic_id: topic_ids })
+                            .where('number_asked > 0')
+                            .pluck(:question_id, :score_sum, :number_asked)
+                            .to_h { |qid, score_sum, asked| [qid, stat_row(score_sum, asked)] }
+  end
+
+  # Per-topic mean score for this student, weakest first.
+  def topic_breakdown
+    report_question_stats.group_by { |qid, _| question_meta.dig(qid, :topic_id) }
+                         .map { |topic_id, pairs| topic_row(topic_id, pairs) }
+                         .sort_by { |topic| topic[:mean_score] }
+  end
+
+  def topic_row(topic_id, pairs)
+    score_sum = pairs.sum { |_, stat| stat[:score_sum] }
+    asked = pairs.sum { |_, stat| stat[:asked] }
+    { topic_id: topic_id, topic_name: topic_names[topic_id], mean_score: mean(score_sum, asked), attempts: asked }
+  end
+
+  # Questions the student scored below the cohort on — biggest shortfall first. The reteach list.
+  def priority_gaps
+    report_question_stats.filter_map { |qid, stat| gap_row(qid, stat) }
+                         .sort_by { |row| -row[:gap] }
+                         .first(PRIORITY_LIMIT)
+  end
+
+  def gap_row(qid, stat)
+    cohort_score = cohort_mean(qid)
+    return if cohort_score.nil? || cohort_score < COHORT_COMPETENCE
+
+    student_score = (stat[:score_sum] / stat[:asked]).round(4)
+    gap = (cohort_score - student_score).round(4)
+    return unless gap.positive?
+
+    question_descriptor(qid).merge(student_score: student_score, cohort_score: cohort_score, gap: gap)
+  end
+
+  # Global mean score (0..1) for a question, or nil when the cohort has not attempted it.
+  def cohort_mean(qid)
+    cohort = global_question_stats[qid]
+    return unless cohort && cohort[:asked].positive?
+
+    (cohort[:score_sum] / cohort[:asked]).round(4)
+  end
+
+  # Hard questions the student nonetheless aced — hardest first. The "give them credit" list.
+  def strengths
+    report_question_stats.filter_map { |qid, stat| strength_row(qid, stat) }
+                         .sort_by { |row| -(row[:difficulty] || 0.0) }
+                         .first(PRIORITY_LIMIT)
+  end
+
+  def strength_row(qid, stat)
+    student_score = (stat[:score_sum] / stat[:asked]).round(4)
+    band = difficulties.dig(qid, :band)
+    return if student_score < STRENGTH_MIN_SCORE || band.nil? || band == :easy
+
+    question_descriptor(qid).merge(student_score: student_score, cohort_score: cohort_mean(qid))
+  end
+end

--- a/app/views/classrooms/gaps.html.slim
+++ b/app/views/classrooms/gaps.html.slim
@@ -1,0 +1,121 @@
+- content_for :title
+  title = 'Gap Analysis - ' + @classroom.name
+
+.tjk-container.tj-gap
+  .tj-gap-header
+    h1.tj-h1 = @classroom.name
+    p.tj-gap-subtitle Gap analysis · difficulty-aware, compared against every Tenjin student
+    = link_to '← Back to classroom', classroom_path(@classroom), class: 'tj-link'
+
+  - if @report.student_count.zero?
+    section.tj-section
+      hr.tj-hr-primary
+      p.tj-gap-empty No enrolled students yet — there is nothing to analyse.
+  - else
+    / Screenshot-ready class summary: who's active + overall standing against the cohort.
+    section.tj-section#summary
+      h2.tj-section-header Class summary
+      hr.tj-hr-primary
+      .tj-gap-cards
+        .tj-gap-card
+          = gap_card_label('Active students', 'Enrolled students who have practised in this subject, out of everyone enrolled.')
+          span.tj-gap-card-value = "#{@report.engagement[:students_active]} / #{@report.student_count}"
+        .tj-gap-card
+          = gap_card_label('Class mastery', "This class's difficulty-weighted average score (0–100%) across every question they've attempted in this subject. Harder questions count for more, so this rewards mastering tough material.")
+          span.tj-gap-card-value = gap_percent(@report.cohort_comparison[:overall][:mastery])
+        .tj-gap-card
+          = gap_card_label('Cohort baseline', 'The difficulty-weighted average that all Tenjin students score on these same questions — the benchmark this class is measured against.')
+          span.tj-gap-card-value = gap_percent(@report.cohort_comparison[:overall][:cohort_mastery])
+        .tj-gap-card
+          = gap_card_label('Standing', 'How this class compares to the cohort baseline: above, on par, or below.')
+          span.tj-gap-card-value = standing_chip(@report.cohort_comparison[:overall][:standing])
+
+    section.tj-section#activity
+      h2.tj-section-header Student activity
+      hr.tj-hr-primary
+      p.tj-gap-note Who is actually practising. Drill into a student for their personal gap report.
+      .tj-gap-cards
+        .tj-gap-card
+          span.tj-gap-card-label Quizzes started
+          span.tj-gap-card-value = @report.engagement[:quizzes_started]
+        .tj-gap-card
+          span.tj-gap-card-label Questions answered
+          span.tj-gap-card-value = @report.engagement[:questions_answered]
+      - if @report.engagement[:per_student].any?
+        div data-controller='table' data-table-page-length-value='15'
+          table.tj-table
+            thead
+              tr
+                th Student
+                th Quizzes
+                th Questions
+                th Last active
+            tbody
+              - @report.engagement[:per_student].each do |e|
+                tr
+                  td = link_to e[:name], student_gap_classroom_path(@classroom, student_id: e[:user_id]), class: 'tj-link'
+                  td = e[:quizzes_started]
+                  td = e[:questions_answered]
+                  td = e[:last_active_at] ? l(e[:last_active_at].to_date, format: :long) : '—'
+
+    section.tj-section#heatmap
+      h2.tj-section-header Topic heatmap
+      hr.tj-hr-primary
+      p.tj-gap-note Mean class score per topic, weakest first.
+      - if @report.topic_heatmap.empty?
+        p.tj-gap-empty No topic activity recorded yet.
+      - else
+        .tj-gap-heatmap
+          - @report.topic_heatmap.each do |topic|
+            .tj-gap-heat-cell style=heat_style(topic[:mean_score])
+              span.tj-gap-heat-topic = topic[:topic_name]
+              span.tj-gap-heat-score = gap_percent(topic[:mean_score])
+              span.tj-gap-heat-meta = "#{topic[:attempts]} attempts · #{topic[:students]} students"
+
+    section.tj-section#cohort
+      h2.tj-section-header Standing vs cohort by topic
+      hr.tj-hr-primary
+      p.tj-gap-note Difficulty-weighted mastery against all Tenjin students on the same questions.
+      - if @report.cohort_comparison[:by_topic].empty?
+        p.tj-gap-empty Not enough data to compare against the cohort yet.
+      - else
+        table.tj-table
+          thead
+            tr
+              th Topic
+              th Class mastery
+              th Cohort
+              th Standing
+          tbody
+            - @report.cohort_comparison[:by_topic].each do |row|
+              tr
+                td = row[:topic_name]
+                td = gap_percent(row[:mastery])
+                td = gap_percent(row[:cohort_mastery])
+                td = standing_chip(row[:standing])
+
+    section.tj-section#hardest
+      h2.tj-section-header Hardest questions
+      hr.tj-hr-primary
+      p.tj-gap-note Ranked by cohort difficulty — low class scores here are misconceptions to reteach.
+      - if @report.hardest_questions.empty?
+        p.tj-gap-empty No question activity recorded yet.
+      - else
+        div data-controller='table' data-table-page-length-value='10'
+          table.tj-table
+            thead
+              tr
+                th Topic
+                th Type
+                th Difficulty
+                th Class score
+                th Attempts
+            tbody
+              - @report.hardest_questions.each do |q|
+                tr
+                  td = q[:topic_name]
+                  td = q[:question_type].to_s.humanize
+                  td = difficulty_band_chip(q[:band])
+                  td = gap_percent(q[:class_mean_score])
+                  td = q[:attempts]
+

--- a/app/views/classrooms/show.html.slim
+++ b/app/views/classrooms/show.html.slim
@@ -3,6 +3,10 @@
 .tjk-container data-controller='classroom'
   h1.tj-h1 style='text-align:center;margin-top:var(--tj-space-3)' = @classroom.name
 
+  - if policy(@classroom).gaps?
+    .tj-gap-link.tj-text-center
+      = link_to 'View Gap Analysis', gaps_classroom_path(@classroom), class: 'tj-btn-primary tj-btn--full'
+
   section.tj-section#homework
     h2.tj-section-header Homework
     hr.tj-hr-primary

--- a/app/views/classrooms/student_gap.html.slim
+++ b/app/views/classrooms/student_gap.html.slim
@@ -1,0 +1,91 @@
+- content_for :title
+  title = 'Gap Analysis - ' + @student.forename + ' ' + @student.surname
+
+.tjk-container.tj-gap
+  .tj-gap-header
+    h1.tj-h1 = "#{@student.forename} #{@student.surname}"
+    p.tj-gap-subtitle Personal gap report · #{@classroom.name}
+    = link_to '← Back to class gap analysis', gaps_classroom_path(@classroom), class: 'tj-link'
+
+  section.tj-section#standing
+    h2.tj-section-header Standing vs cohort
+    hr.tj-hr-primary
+    .tj-gap-cards
+      .tj-gap-card
+        span.tj-gap-card-label Their mastery
+        span.tj-gap-card-value = gap_percent(@report.cohort_comparison[:overall][:mastery])
+      .tj-gap-card
+        span.tj-gap-card-label Cohort baseline
+        span.tj-gap-card-value = gap_percent(@report.cohort_comparison[:overall][:cohort_mastery])
+      .tj-gap-card
+        span.tj-gap-card-label Standing
+        span.tj-gap-card-value = standing_chip(@report.cohort_comparison[:overall][:standing])
+
+  section.tj-section#topics
+    h2.tj-section-header Topic strengths &amp; gaps
+    hr.tj-hr-primary
+    - if @report.topic_breakdown.empty?
+      p.tj-gap-empty This student has not attempted any questions in this subject yet.
+    - else
+      table.tj-table
+        thead
+          tr
+            th Topic
+            th Mean score
+            th Attempts
+        tbody
+          - @report.topic_breakdown.each do |topic|
+            tr
+              td = topic[:topic_name]
+              td style=heat_style(topic[:mean_score]) = gap_percent(topic[:mean_score])
+              td = topic[:attempts]
+
+  section.tj-section#priority
+    h2.tj-section-header Priority gaps
+    hr.tj-hr-primary
+    p.tj-gap-note Questions this student got wrong that most of the cohort got right — reteach these first.
+    - if @report.priority_gaps.empty?
+      p.tj-gap-empty No priority gaps — this student is not trailing the cohort on any single question.
+    - else
+      table.tj-table
+        thead
+          tr
+            th Topic
+            th Type
+            th Difficulty
+            th Their score
+            th Cohort
+            th Gap
+        tbody
+          - @report.priority_gaps.each do |q|
+            tr
+              td = q[:topic_name]
+              td = q[:question_type].to_s.humanize
+              td = difficulty_band_chip(q[:band])
+              td = gap_percent(q[:student_score])
+              td = gap_percent(q[:cohort_score])
+              td = gap_percent(q[:gap])
+
+  section.tj-section#strengths
+    h2.tj-section-header Strengths
+    hr.tj-hr-primary
+    p.tj-gap-note Hard questions this student aced — worth recognising.
+    - if @report.strengths.empty?
+      p.tj-gap-empty No standout strengths recorded yet.
+    - else
+      table.tj-table
+        thead
+          tr
+            th Topic
+            th Type
+            th Difficulty
+            th Their score
+            th Cohort
+        tbody
+          - @report.strengths.each do |q|
+            tr
+              td = q[:topic_name]
+              td = q[:question_type].to_s.humanize
+              td = difficulty_band_chip(q[:band])
+              td = gap_percent(q[:student_score])
+              td = gap_percent(q[:cohort_score])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,12 @@ Rails.application.routes.draw do
     end
   end
   resources :leaderboard, only:[:show, :index]
-  resources :classrooms, only: [:show, :index, :update]
+  resources :classrooms, only: [:show, :index, :update] do
+    member do
+      get 'gaps'
+      get 'gaps/student/:student_id', to: 'classrooms#student_gap', as: :student_gap
+    end
+  end
   resources :questions do
     collection do
       get 'topic' 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,4 +32,6 @@ if Rails.env.development? || ENV['SEED_TEST_USERS'] == 'true'
   load Rails.root.join('db/seeds/development_questions.rb')
   load Rails.root.join('db/seeds/development_users.rb')
   load Rails.root.join('db/seeds/development_lessons.rb')
+  # Needs the classrooms/students from development_users, so it must load last.
+  load Rails.root.join('db/seeds/development_gap_analysis.rb')
 end

--- a/db/seeds/development_gap_analysis.rb
+++ b/db/seeds/development_gap_analysis.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+# Seeds a deliberately-shaped scenario for the teacher gap-analysis surface (classrooms#gaps).
+# The reports read the durable per-student rollup (student_question_statistics) and a global cohort
+# baseline (question_statistics); neither is exercised by the other dev seeds, so without this the
+# gap analysis renders empty. Development / SEED_TEST_USERS only, and idempotent: it wipes its own
+# previous output (demo questions by sentinel external_id, plus the showcase class's rollups) and
+# rebuilds, so re-running — even after the topic set changes — never duplicates or leaves stragglers.
+#
+# The scenario is built around three legible archetypes in "7 Computer Science" so the surface tells
+# a clear story rather than showing random noise:
+#   * Ada Lovelace  — high ability: above the cohort in every topic, aces the hardest questions.
+#   * Charlie Brown — low ability:  below the cohort, a long list of priority gaps on the basics.
+#   * Beth Jones    — mixed:        solid overall but clearly failing two topics (Networks, Data).
+# The rest of the class spreads across the cohort average, and each topic carries a "climate" offset
+# so the class heatmap shows a genuine weak→strong gradient across every topic in the subject. One
+# pupil (Sam Carter) is enrolled but inactive so the engagement section shows a participation gap.
+unless Rails.env.development? || ENV['SEED_TEST_USERS'] == 'true'
+  raise "Gap-analysis seeds can only be loaded in development or with SEED_TEST_USERS=true, not #{Rails.env}."
+end
+
+require 'zlib'
+
+# Deterministic so re-seeding produces the same (sensible) numbers.
+GAP_RNG = Random.new(20_260_623)
+
+# Six questions per topic with a fixed cohort mean score (its "ease"): two easy, two medium, two
+# hard. Drives both the difficulty bands and the cohort baseline every comparison is judged against.
+GAP_QUESTION_EASE = [0.86, 0.80, 0.56, 0.50, 0.28, 0.22].freeze
+# Placeholder topics the bare dev seed creates, and utility/import-artefact topics — skipped when the
+# subject has a real imported curriculum so the heatmap shows the actual specification, not noise.
+GAP_PLACEHOLDER_TOPICS = %w[Algorithms Networks Programming Data].freeze
+GAP_UTILITY_TOPICS = ['Question Tester', 'Question Lucky Dip'].freeze
+# Reserved external_id range so demo questions never collide with real/imported ones.
+GAP_EID_BASE = 970_000
+GAP_EID_SPAN = 100_000
+
+def gap_showcase_classroom
+  Classroom.find_by(client_id: 'development-7c')
+end
+
+# Real curriculum topics if the subject was imported, otherwise the bare placeholders. Sorted for a
+# stable external_id assignment and struggle-topic pick.
+def gap_topics_for(subject)
+  active = subject.topics.where(active: true)
+  curriculum = active.where.not(name: GAP_PLACEHOLDER_TOPICS + GAP_UTILITY_TOPICS)
+  (curriculum.exists? ? curriculum : active.where(name: GAP_PLACEHOLDER_TOPICS)).order(:name).to_a
+end
+
+# The two topics our "mixed" archetype falls apart on: a networking and a data topic if present.
+def gap_struggle_topics(topics)
+  picks = [topics.find { |t| t.name.match?(/network/i) }, topics.find { |t| t.name.match?(/data/i) }]
+  picks.compact.uniq.presence || topics.first(2)
+end
+
+# How the class as a whole fares on a topic (-0.20..+0.20), stable per topic name. Gives the heatmap
+# a real gradient instead of every topic hovering around the same mean.
+def gap_topic_climate(topic)
+  (((Zlib.crc32(topic.name) % 1000) / 1000.0) * 0.40) - 0.20
+end
+
+# --- Reset previous output -----------------------------------------------------------------------
+
+def gap_reset!(classroom)
+  demo_ids = Question.where(external_id: GAP_EID_BASE...(GAP_EID_BASE + GAP_EID_SPAN)).pluck(:id)
+  StudentQuestionStatistic.where(question_id: demo_ids).delete_all
+  QuestionStatistic.where(question_id: demo_ids).delete_all
+  Question.where(id: demo_ids).destroy_all
+  UsageStatistic.where(user_id: classroom.users.where(role: 'student').select(:id)).delete_all
+end
+
+# --- Questions + cohort baseline -----------------------------------------------------------------
+
+def gap_demo_questions(topic, topic_index)
+  GAP_QUESTION_EASE.each_with_index.map do |ease, question_index|
+    question = gap_create_question(topic, GAP_EID_BASE + (topic_index * 10) + question_index, question_index)
+    gap_create_question_statistic(question, ease)
+    [question, ease]
+  end
+end
+
+def gap_create_question(topic, external_id, question_index)
+  question_type = question_index.even? ? 'multiple' : 'short_answer'
+  Question.create!(
+    external_id:, topic:, question_type:,
+    question_text: "[#{topic.name}] Sample question #{question_index + 1}",
+    answers_attributes: gap_answers_for(question_type)
+  )
+end
+
+def gap_answers_for(question_type)
+  return [{ text: 'Correct answer', correct: true }] if question_type == 'short_answer'
+
+  [{ text: 'Correct answer', correct: true },
+   { text: 'Distractor A', correct: false },
+   { text: 'Distractor B', correct: false }]
+end
+
+# Heavily sampled so the difficulty engine trusts the empirical mean and the band lands as intended.
+def gap_create_question_statistic(question, ease)
+  asked = 300
+  QuestionStatistic.create!(question:, number_asked: asked,
+                            score_sum: (asked * ease).round.to_f, number_correct: (asked * ease).round)
+end
+
+# --- Students ------------------------------------------------------------------------------------
+
+def gap_upsert_student(school, classroom, key, forename, surname)
+  student = upsert_user(school:, username: "gap-#{key}", forename:, surname:,
+                        role: 'student', upi: "development-gap-#{key}")
+  enroll(user: student, classroom:)
+  student
+end
+
+# Per-topic ability (0..1): archetypes are deliberate, fillers spread around the cohort, and every
+# pupil is nudged by the topic's class climate so the heatmap varies topic to topic.
+def gap_ability(student, profile, topic, struggle_ids)
+  climate = gap_topic_climate(topic)
+  case profile
+  when :high then (0.95 + (climate * 0.3)).clamp(0.0, 1.0)
+  when :low then (0.24 + (climate * 0.3)).clamp(0.0, 1.0)
+  when :struggling then gap_struggling_ability(topic, climate, struggle_ids)
+  else (gap_filler_base(student) + climate + (GAP_RNG.rand * 0.08) - 0.04).clamp(0.0, 1.0)
+  end
+end
+
+def gap_struggling_ability(topic, climate, struggle_ids)
+  return (0.24 + (climate * 0.2)).clamp(0.0, 1.0) if struggle_ids.include?(topic.id)
+
+  # Squarely mid-table on everything else, so overall she reads "on par" and the two weak topics —
+  # not a low headline number — are what stands out.
+  (0.52 + (climate * 0.5)).clamp(0.0, 1.0)
+end
+
+def gap_filler_base(student)
+  0.32 + ((student.id % 7) / 7.0 * 0.46) # ~0.32..0.78, stable per pupil
+end
+
+# A pupil's expected mean score on a question: ability nudged by how easy the item is, plus noise.
+def gap_expected_score(ability, ease)
+  (ability + ((ease - 0.5) * 0.5) + (GAP_RNG.rand * 0.08) - 0.04).clamp(0.0, 1.0)
+end
+
+def gap_seed_student(student, profile, demo_by_topic, struggle_ids)
+  demo_by_topic.each do |topic, questions|
+    ability = gap_ability(student, profile, topic, struggle_ids)
+    questions.each { |question, ease| gap_create_rollup(student, question, gap_expected_score(ability, ease)) }
+    gap_create_usage(student, topic, profile) unless profile == :inactive
+  end
+end
+
+def gap_create_rollup(student, question, expected)
+  asked = GAP_RNG.rand(4..10)
+  score = (asked * expected).round(1)
+  StudentQuestionStatistic.create!(user: student, question:, number_asked: asked, score_sum: score,
+                                   number_correct: score.round, last_asked_at: GAP_RNG.rand(1..21).days.ago)
+end
+
+def gap_create_usage(student, topic, profile)
+  quizzes = profile == :low ? GAP_RNG.rand(1..3) : GAP_RNG.rand(3..10)
+  UsageStatistic.create!(user: student, topic:, quizzes_started: quizzes,
+                         questions_answered: quizzes * GAP_RNG.rand(6..10), date: GAP_RNG.rand(1..21).days.ago)
+end
+
+# --- Build the scenario --------------------------------------------------------------------------
+
+classroom = gap_showcase_classroom
+
+if classroom.nil? || classroom.subject.nil?
+  Rails.logger.info('Gap-analysis seed skipped: showcase classroom "development-7c" not found.')
+else
+  gap_reset!(classroom)
+
+  school = classroom.school
+  topics = gap_topics_for(classroom.subject)
+  demo_by_topic = topics.each_with_index.to_h { |topic, index| [topic, gap_demo_questions(topic, index)] }
+  struggle_ids = gap_struggle_topics(topics).map(&:id)
+
+  archetypes = [
+    [gap_upsert_student(school, classroom, 'ada', 'Ada', 'Lovelace'), :high],
+    [gap_upsert_student(school, classroom, 'charlie', 'Charlie', 'Brown'), :low],
+    [gap_upsert_student(school, classroom, 'beth', 'Beth', 'Jones'), :struggling]
+  ]
+
+  fillers = [
+    [gap_upsert_student(school, classroom, 'dev', 'Dev', 'Patel'), :filler],
+    [gap_upsert_student(school, classroom, 'ellie', 'Ellie', 'Wong'), :filler],
+    [gap_upsert_student(school, classroom, 'mia', 'Mia', 'Khan'), :filler],
+    [gap_upsert_student(school, classroom, 'tom', 'Tom', 'Reed'), :filler],
+    [gap_upsert_student(school, classroom, 'sam', 'Sam', 'Carter'), :inactive]
+  ]
+
+  (archetypes + fillers).each { |student, profile| gap_seed_student(student, profile, demo_by_topic, struggle_ids) }
+
+  # Give every other already-enrolled pupil cohort-average data so the class is fully populated.
+  seeded_ids = (archetypes + fillers).map { |student, _| student.id }
+  classroom.users.where(role: 'student').where.not(id: seeded_ids).find_each do |student|
+    gap_seed_student(student, :filler, demo_by_topic, struggle_ids)
+  end
+
+  struggle_names = topics.select { |t| struggle_ids.include?(t.id) }.map(&:name).join(' & ')
+  puts %(Gap-analysis showcase seeded for "7 Computer Science" across #{topics.size} topics:)
+  puts '  Ada Lovelace   — high ability  (above cohort everywhere; aces the hardest questions)'
+  puts '  Charlie Brown  — low ability   (below cohort; many priority gaps on the basics)'
+  puts %(  Beth Jones     — mixed         (around the class average, but clearly failing #{struggle_names}))
+  puts '  + classmates spread around the cohort; Sam Carter is enrolled but inactive.'
+  puts '  Sign in as teacher1 / password → "7 Computer Science" → View Gap Analysis.'
+end

--- a/spec/policies/classroom_policy_spec.rb
+++ b/spec/policies/classroom_policy_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClassroomPolicy do
+  subject(:policy) { described_class.new(user, classroom) }
+
+  let(:school) { create(:school) }
+  let(:classroom) { create(:classroom, school: school) }
+
+  describe '#gaps?' do
+    context 'with a teacher from the same school' do
+      let(:user) { create(:teacher, school: school) }
+
+      it { expect(policy.gaps?).to be(true) }
+    end
+
+    context 'with a teacher from another school' do
+      let(:user) { create(:teacher) }
+
+      it { expect(policy.gaps?).to be(false) }
+    end
+
+    context 'with a student in the school' do
+      let(:user) { create(:student, school: school) }
+
+      it { expect(policy.gaps?).to be(false) }
+    end
+  end
+end

--- a/spec/requests/classroom_gaps_request_spec.rb
+++ b/spec/requests/classroom_gaps_request_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Classroom gap analysis', :default_creates, type: :request do
+  before { create(:enrollment, school: school, classroom: classroom, user: student) }
+
+  describe 'GET /classrooms/:id/gaps' do
+    it 'renders the gap analysis for a teacher in the same school' do
+      sign_in teacher
+
+      get gaps_classroom_path(classroom)
+
+      expect(response).to have_http_status(:ok)
+      expect(Capybara.string(response.body)).to have_text('Gap analysis')
+    end
+
+    it 'redirects a teacher from another school' do
+      sign_in create(:teacher)
+
+      get gaps_classroom_path(classroom)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'redirects a student' do
+      sign_in student
+
+      get gaps_classroom_path(classroom)
+
+      expect(response).not_to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET /classrooms/:id/gaps/student/:student_id' do
+    it 'renders the per-student drill for an enrolled pupil' do
+      sign_in teacher
+
+      get student_gap_classroom_path(classroom, student_id: student.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(Capybara.string(response.body)).to have_text('Personal gap report')
+    end
+
+    it 'cannot reach a pupil who is not enrolled in the class' do
+      sign_in teacher
+      outsider = create(:student, school: school)
+
+      expect { get student_gap_classroom_path(classroom, student_id: outsider.id) }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/services/analytics/class_gap_report_spec.rb
+++ b/spec/services/analytics/class_gap_report_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::ClassGapReport do
+  subject(:report) { described_class.call(classroom) }
+
+  let(:subject_area) { create(:subject) }
+  let(:classroom) { create(:classroom, subject: subject_area) }
+  let(:topic_a) { create(:topic, subject: subject_area, name: 'Algorithms') }
+  let(:topic_b) { create(:topic, subject: subject_area, name: 'Networks') }
+  let(:alice) { create(:student, school: classroom.school) }
+  let(:bob) { create(:student, school: classroom.school) }
+
+  def enrol(user)
+    Enrollment.create!(classroom: classroom, user: user)
+  end
+
+  def student_stat(user, question, asked:, score:)
+    create(:student_question_statistic, user: user, question: question,
+                                        number_asked: asked, number_correct: score.to_i, score_sum: score)
+  end
+
+  before do
+    enrol(alice)
+    enrol(bob)
+  end
+
+  describe 'topic heatmap' do
+    let(:easy_q) { create(:question, topic: topic_a, question_type: 'multiple') }
+    let(:hard_q) { create(:question, topic: topic_b, question_type: 'short_answer') }
+
+    before do
+      # Algorithms: 12/20 => 0.6.  Networks: 4/20 => 0.2 (weakest).
+      student_stat(alice, easy_q, asked: 10, score: 8.0)
+      student_stat(bob, easy_q, asked: 10, score: 4.0)
+      student_stat(alice, hard_q, asked: 10, score: 3.0)
+      student_stat(bob, hard_q, asked: 10, score: 1.0)
+    end
+
+    it 'orders topics weakest first with class mean scores' do
+      heatmap = report.topic_heatmap
+
+      expect(heatmap.pluck(:topic_name)).to eq(%w[Networks Algorithms])
+      expect(heatmap.first).to include(topic_name: 'Networks', mean_score: 0.2, attempts: 20, students: 2)
+      expect(heatmap.last).to include(topic_name: 'Algorithms', mean_score: 0.6)
+    end
+  end
+
+  describe 'hardest questions' do
+    let(:gentle) { create(:question, topic: topic_a, question_type: 'multiple') }
+    let(:brutal) { create(:short_answer_question, topic: topic_b) }
+
+    before do
+      student_stat(alice, gentle, asked: 10, score: 9.0)
+      student_stat(alice, brutal, asked: 10, score: 1.0)
+      # Cohort-wide stats drive the difficulty engine: brutal is hard, gentle is easy.
+      create(:question_statistic, question: gentle, number_asked: 1000, number_correct: 900, score_sum: 900.0)
+      create(:question_statistic, question: brutal, number_asked: 1000, number_correct: 100, score_sum: 100.0)
+    end
+
+    it 'ranks by cohort difficulty, hardest first, with band, type and class mean' do
+      hardest = report.hardest_questions
+
+      expect(hardest.first).to include(question_id: brutal.id, band: :hard,
+                                       question_type: 'short_answer', class_mean_score: 0.1)
+      expect(hardest.first[:difficulty]).to be > hardest.last[:difficulty]
+      expect(hardest.last).to include(question_id: gentle.id, band: :easy)
+    end
+
+    it 'caps the list at HARDEST_QUESTIONS_LIMIT' do
+      create_list(:question, described_class::HARDEST_QUESTIONS_LIMIT + 3, topic: topic_a).each do |q|
+        student_stat(alice, q, asked: 5, score: 2.0)
+      end
+
+      expect(report.hardest_questions.size).to eq(described_class::HARDEST_QUESTIONS_LIMIT)
+    end
+  end
+
+  describe 'cohort comparison' do
+    let(:question) { create(:short_answer_question, topic: topic_a) }
+
+    before do
+      # Class averages 0.6 on an item the wider cohort only manages 0.1 on => well above cohort.
+      student_stat(alice, question, asked: 10, score: 6.0)
+      student_stat(bob, question, asked: 10, score: 6.0)
+      create(:question_statistic, question: question, number_asked: 1000, number_correct: 100, score_sum: 100.0)
+    end
+
+    it 'reports difficulty-weighted mastery above the global cohort' do
+      overall = report.cohort_comparison[:overall]
+
+      expect(overall[:mastery]).to be_within(0.01).of(0.6)
+      expect(overall[:cohort_mastery]).to be_within(0.01).of(0.1)
+      expect(overall[:delta]).to be > 0
+      expect(overall[:standing]).to eq(:above)
+    end
+
+    it 'breaks the comparison down per topic' do
+      by_topic = report.cohort_comparison[:by_topic]
+
+      expect(by_topic.pluck(:topic_name)).to include('Algorithms')
+      expect(by_topic.first).to include(:mastery, :cohort_mastery, :delta, :standing, :topic_id, :topic_name)
+    end
+  end
+
+  describe 'engagement' do
+    let(:question) { create(:question, topic: topic_a) }
+
+    before do
+      # Answered counts come from the durable per-question rollup; quizzes-started from usage stats.
+      student_stat(alice, question, asked: 25, score: 20.0)
+      student_stat(bob, question, asked: 8, score: 4.0)
+      create(:usage_statistic, user: alice, topic: topic_a, quizzes_started: 3)
+      create(:usage_statistic, user: bob, topic: topic_a, quizzes_started: 1)
+    end
+
+    it 'counts answered questions from the rollup and quizzes from usage statistics' do
+      engagement = report.engagement
+
+      expect(engagement[:students_active]).to eq(2)
+      expect(engagement[:quizzes_started]).to eq(4)
+      expect(engagement[:questions_answered]).to eq(33)
+      expect(engagement[:per_student].first[:name]).to eq("#{alice.forename} #{alice.surname}")
+    end
+
+    it 'counts a student who has started a quiz but not yet had answers rolled up as active' do
+      create(:usage_statistic, user: create(:student, school: classroom.school).tap { |s| enrol(s) },
+                               topic: topic_a, quizzes_started: 2)
+
+      expect(report.engagement[:students_active]).to eq(3)
+    end
+  end
+
+  describe 'with no data' do
+    it 'returns empty sections for an empty classroom' do
+      empty = described_class.call(create(:classroom, subject: subject_area))
+
+      expect(empty.student_count).to eq(0)
+      expect(empty.topic_heatmap).to eq([])
+      expect(empty.hardest_questions).to eq([])
+      expect(empty.cohort_comparison[:overall][:standing]).to eq(:unknown)
+      expect(empty.engagement[:students_active]).to eq(0)
+    end
+
+    it 'handles a classroom with no subject' do
+      no_subject = described_class.call(create(:classroom, subject: nil))
+
+      expect(no_subject.topic_heatmap).to eq([])
+    end
+  end
+
+  describe 'query efficiency' do
+    let(:question) { create(:question, topic: topic_a) }
+
+    before do
+      student_stat(alice, question, asked: 5, score: 3.0)
+      student_stat(bob, question, asked: 5, score: 2.0)
+    end
+
+    it 'never issues a query per student (no N+1)' do
+      create_list(:student, 5, school: classroom.school).each do |s|
+        enrol(s)
+        student_stat(s, question, asked: 4, score: 2.0)
+      end
+
+      queries = 0
+      counter = ->(_n, _s, _f, _i, _payload) { queries += 1 }
+      ActiveSupport::Notifications.subscribed(counter, 'sql.active_record') do
+        report = described_class.call(classroom)
+        report.topic_heatmap
+        report.hardest_questions
+        report.cohort_comparison
+        report.engagement
+      end
+
+      # A small, student-count-independent number of aggregate queries.
+      expect(queries).to be < 25
+    end
+  end
+end

--- a/spec/services/analytics/student_gap_report_spec.rb
+++ b/spec/services/analytics/student_gap_report_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::StudentGapReport do
+  subject(:report) { described_class.call(student, classroom) }
+
+  let(:subject_area) { create(:subject) }
+  let(:classroom) { create(:classroom, subject: subject_area) }
+  let(:topic_a) { create(:topic, subject: subject_area, name: 'Algorithms') }
+  let(:topic_b) { create(:topic, subject: subject_area, name: 'Networks') }
+  let(:student) { create(:student, school: classroom.school) }
+
+  def student_stat(question, asked:, score:)
+    create(:student_question_statistic, user: student, question: question,
+                                        number_asked: asked, number_correct: score.to_i, score_sum: score)
+  end
+
+  describe 'topic breakdown' do
+    let(:strong_q) { create(:question, topic: topic_a) }
+    let(:weak_q) { create(:question, topic: topic_b) }
+
+    before do
+      student_stat(strong_q, asked: 10, score: 8.0) # Algorithms 0.8
+      student_stat(weak_q, asked: 10, score: 2.0)   # Networks 0.2 (weakest)
+    end
+
+    it 'orders topics weakest first with mean scores' do
+      breakdown = report.topic_breakdown
+
+      expect(breakdown.pluck(:topic_name)).to eq(%w[Networks Algorithms])
+      expect(breakdown.first).to include(topic_name: 'Networks', mean_score: 0.2, attempts: 10)
+    end
+
+    it 'ignores questions the student has never been asked' do
+      create(:student_question_statistic, user: student, question: create(:question, topic: topic_a),
+                                          number_asked: 0, number_correct: 0, score_sum: 0.0)
+
+      expect(report.topic_breakdown.sum { |t| t[:attempts] }).to eq(20)
+    end
+  end
+
+  describe 'cohort comparison' do
+    let(:question) { create(:short_answer_question, topic: topic_a) }
+
+    before do
+      student_stat(question, asked: 10, score: 1.0) # student 0.1
+      # Cohort breezes through it at 0.9 => student well below.
+      create(:question_statistic, question: question, number_asked: 1000, number_correct: 900, score_sum: 900.0)
+    end
+
+    it 'places the student below the global cohort' do
+      overall = report.cohort_comparison[:overall]
+
+      expect(overall[:mastery]).to be_within(0.01).of(0.1)
+      expect(overall[:cohort_mastery]).to be_within(0.01).of(0.9)
+      expect(overall[:standing]).to eq(:below)
+    end
+  end
+
+  describe 'priority gaps' do
+    let(:cohort_easy) { create(:question, topic: topic_a, question_type: 'multiple') }
+    let(:also_hard) { create(:short_answer_question, topic: topic_b) }
+
+    before do
+      # Student bombs a question the cohort finds easy => top priority gap.
+      student_stat(cohort_easy, asked: 10, score: 1.0)
+      create(:question_statistic, question: cohort_easy, number_asked: 1000, number_correct: 900, score_sum: 900.0)
+      # Student also struggles, but so does the cohort => not a priority gap.
+      student_stat(also_hard, asked: 10, score: 1.0)
+      create(:question_statistic, question: also_hard, number_asked: 1000, number_correct: 150, score_sum: 150.0)
+    end
+
+    it 'surfaces questions the student trails the cohort on, biggest gap first' do
+      gaps = report.priority_gaps
+
+      expect(gaps.first).to include(question_id: cohort_easy.id, student_score: 0.1)
+      expect(gaps.first[:cohort_score]).to be_within(0.01).of(0.9)
+      expect(gaps.first[:gap]).to be_within(0.01).of(0.8)
+      expect(gaps.pluck(:question_id)).not_to include(also_hard.id)
+    end
+  end
+
+  describe 'strengths' do
+    let(:hard_aced) { create(:short_answer_question, topic: topic_a) }
+    let(:easy_aced) { create(:question, topic: topic_a, question_type: 'multiple') }
+
+    before do
+      # A genuinely hard question the student nails.
+      student_stat(hard_aced, asked: 10, score: 9.0)
+      create(:question_statistic, question: hard_aced, number_asked: 1000, number_correct: 100, score_sum: 100.0)
+      # An easy question they also nail — not noteworthy, excluded.
+      student_stat(easy_aced, asked: 10, score: 10.0)
+      create(:question_statistic, question: easy_aced, number_asked: 1000, number_correct: 950, score_sum: 950.0)
+    end
+
+    it 'surfaces hard questions the student aced and skips easy ones' do
+      strengths = report.strengths
+
+      expect(strengths.pluck(:question_id)).to include(hard_aced.id)
+      expect(strengths.pluck(:question_id)).not_to include(easy_aced.id)
+      expect(strengths.first).to include(band: :hard)
+      expect(strengths.first[:student_score]).to be >= described_class::STRENGTH_MIN_SCORE
+    end
+  end
+
+  describe 'with no data' do
+    it 'returns empty sections when the student has no statistics' do
+      expect(report.topic_breakdown).to eq([])
+      expect(report.priority_gaps).to eq([])
+      expect(report.strengths).to eq([])
+      expect(report.cohort_comparison[:overall][:standing]).to eq(:unknown)
+    end
+  end
+end

--- a/spec/system/classroom/teacher_views_gap_analysis_spec.rb
+++ b/spec/system/classroom/teacher_views_gap_analysis_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Teacher views gap analysis', :default_creates, :js, type: :system do
+  let(:classroom) { create(:classroom, subject: subject, school: teacher.school) }
+  let(:hard_question) { create(:short_answer_question, topic: topic) }
+
+  before do
+    create(:enrollment, classroom: classroom, user: teacher)
+    create(:enrollment, classroom: classroom, user: student)
+    create(:student_question_statistic, user: student, question: hard_question,
+                                        number_asked: 10, number_correct: 2, score_sum: 2.0)
+    create(:question_statistic, question: hard_question, number_asked: 1000, number_correct: 800, score_sum: 800.0)
+    create(:usage_statistic, user: student, topic: topic, quizzes_started: 4)
+    sign_in teacher
+  end
+
+  it 'renders the class gap analysis and drills into a student' do
+    visit(classroom_path(classroom))
+    click_link('View Gap Analysis')
+
+    expect(page).to have_text('Gap analysis')
+    expect(page).to have_css('h2.tj-section-header', text: /student activity/i)
+    expect(page).to have_css('h2.tj-section-header', text: /topic heatmap/i)
+    expect(page).to have_css('h2.tj-section-header', text: /hardest questions/i)
+    expect(page).to have_text(topic.name)
+    # Answered count comes from the durable rollup (number_asked: 10), not the unwritten usage column.
+    expect(page).to have_css('.tj-gap-card', text: /questions answered\s*10/i)
+
+    click_link("#{student.forename} #{student.surname}")
+
+    expect(page).to have_text('Personal gap report')
+    expect(page).to have_css('h2.tj-section-header', text: /priority gaps/i)
+  end
+end


### PR DESCRIPTION
- Add Analytics::StudentGapReport service for detailed student performance analysis.
- Create views for classroom gap analysis and individual student gap reports.
- Seed development database with structured gap analysis data for testing.
- Implement ClassroomPolicy to restrict access to gap analysis based on user role.
- Add request specs for classroom gap analysis endpoints.
- Create system specs for teacher viewing gap analysis and drilling into student reports.
- Add tests for Analytics::ClassGapReport and Analytics::StudentGapReport to ensure correct functionality.